### PR TITLE
remove Base class -- we don't really use it

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -16,7 +16,7 @@ module Synapse
   
   attr_reader :service_watchers
 
-  class Synapse < Base
+  class Synapse
     def initialize(opts={})
       # disable configuration until this is started
       @configure_enabled = false

--- a/lib/synapse/base.rb
+++ b/lib/synapse/base.rb
@@ -3,15 +3,4 @@ module Synapse
     @@log = Logger.new STDOUT unless defined?(@@log)
     @@log.debug message
   end
-
-  def safe_run(command)
-    res = `#{command}`.chomp
-    raise "command '#{command}' failed to run:\n#{res}" unless $?.success?
-  end
-
-  class Base
-    def initialize
-      super
-    end
-  end
 end

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1,5 +1,5 @@
 module Synapse
-  class Haproxy < Base
+  class Haproxy
     attr_reader :opts
     def initialize(opts)
       super()
@@ -90,7 +90,8 @@ module Synapse
 
     # restarts haproxy
     def restart
-      safe_run(opts['reload_command'])
+      res = `#{opts['reload_command']}`.chomp
+      raise "failed to reload haproxy via #{opts['reload_command']}: #{res}" unless $?.success?
     end
   end
 end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -1,6 +1,6 @@
 
 module Synapse
-  class BaseWatcher < Base
+  class BaseWatcher
     attr_reader :backends, :name, :listen, :local_port, :server_options
 
     def initialize(opts={}, synapse)


### PR DESCRIPTION
at some point, we should rename `base.rb` to, like, `logging.rb` or something but that would make rebasing difficult ATM with so many pull requests in-flight
