### PR TITLE
Bind haproxy to all interfaces - not just localhost

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -550,7 +550,7 @@ module Synapse
         new_config << generate_backend_stanza(watcher, @watcher_configs[watcher.name]['backend'])
       end
 
-      log.debug "synapse: new haproxy config: #{new_config}"
+      log.debug "synapse: new haproxy config: #{new_config.flatten.join("\n")}"
       return new_config.flatten.join("\n")
     end
 
@@ -616,7 +616,7 @@ module Synapse
       stanza = [
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-        "\tbind localhost:#{watcher.haproxy['port']}",
+        "\tbind 0.0.0.0:#{watcher.haproxy['port']}",
         "\tdefault_backend #{watcher.name}"
       ]
     end


### PR DESCRIPTION
I've recently been playing with machines with multiple ips, and have had problems with synapse. It eventually boiled down to haproxy binding only on localhost.

My fix here is just to bind to everything. Not sure if there are any weird implications of doing this but it works fine for me. A better fix might be to specify in the config file the IP you want to bind to.
