### PR TITLE
Load services dynamically

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,24 @@ PATH
   remote: .
   specs:
     synapse (0.6.0)
+      aws-sdk (~> 1.25.0)
       zk (~> 1.9.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    aws-sdk (1.25.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4, < 1.6.0)
+      uuidtools (~> 2.1)
     coderay (1.0.9)
     diff-lcs (1.2.4)
+    json (1.8.1)
     little-plugger (1.1.3)
     logging (1.7.2)
       little-plugger (>= 1.1.3)
     method_source (0.8.2)
+    nokogiri (1.5.10)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -28,10 +35,11 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     slop (3.4.6)
+    uuidtools (2.1.4)
     zk (1.9.2)
       logging (~> 1.7.2)
       zookeeper (~> 1.4.0)
-    zookeeper (1.4.6)
+    zookeeper (1.4.7)
 
 PLATFORMS
   ruby

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -2,6 +2,7 @@ require_relative "synapse/version"
 require_relative "synapse/base"
 require_relative "synapse/haproxy"
 require_relative "synapse/service_watcher"
+require_relative "synapse/service_discoverer"
 
 require 'logger'
 require 'json'
@@ -11,9 +12,20 @@ include Synapse
 module Synapse
   class Synapse
     def initialize(opts={})
-      # create the service watchers for all our services
+
+      # create the service watchers for all our static services
       raise "specify a list of services to connect in the config" unless opts.has_key?('services')
-      @service_watchers = create_service_watchers(opts['services'])
+      @static_service_watchers = create_static_service_watchers(opts['services'])
+      @dynamic_service_watchers = []
+
+      # Do we have a dynamic list?
+      if opts.key?('service_discoverer')
+        # Load up the service discoveror
+        @service_discoverer = create_service_discoverer(opts['service_discoverer'])
+      else
+        # Static
+        @service_discoverer = nil
+      end
 
       # create the haproxy object
       raise "haproxy config section is missing" unless opts.has_key?('haproxy')
@@ -27,12 +39,18 @@ module Synapse
     def run
       log.info "synapse: starting..."
 
-      # start all the watchers
-      @service_watchers.map { |watcher| watcher.start }
+      # Start the service discoverer
+      @service_discoverer.start
+
+      # start all the static watchers
+      @static_service_watchers.map { |watcher| watcher.start }
 
       # main loop
       loops = 0
       loop do
+
+        update_service_watchers
+
         @service_watchers.each do |w|
           raise "synapse: service watcher #{w.name} failed ping!" unless w.ping?
         end
@@ -55,7 +73,7 @@ module Synapse
     end
 
     private
-    def create_service_watchers(services={})
+    def create_static_service_watchers(services={})
       service_watchers =[]
       services.each do |service_name, service_config|
         service_watchers << ServiceWatcher.create(service_name, service_config, self)
@@ -64,5 +82,42 @@ module Synapse
       return service_watchers
     end
 
+    private
+    def create_service_discoverer(opts)
+      static_service_names = @static_service_watchers.map { |watcher| watcher.name }
+      return ServiceDiscoverer.create(opts, static_service_names, self)
+    end
+
+    private
+    def update_service_watchers
+
+      # If we don't have a service discoverer then we just want to return the static service
+      # watchers
+      unless @service_discoverer
+        @service_watchers = @static_service_watchers
+      else
+        # We have a service discoverer - is it available?
+        raise "synapse: service discoverer failed ping!" unless @service_discoverer.ping?
+
+        # We need to modify our list of dynamic service watchers. First remove any that
+        # aren't present in the discoverer's service list
+        discovered = @service_discoverer.services
+        @dynamic_service_watchers.keep_if { |svc| discovered.key?(svc.name) }
+
+        # Create any new watchers and add them to the list
+        discovered.each do |service_name, config|
+          if @dynamic_service_watchers.index { |svc| svc.name == service_name }.nil?
+            # Isn't in the list - lets add it and start it
+            watcher = ServiceWatcher.create(service_name, config, self)
+            watcher.start
+            @dynamic_service_watchers << watcher
+          end
+        end
+
+        # Now merge the two arrays
+        @service_watchers = @static_service_watchers | @dynamic_service_watchers
+
+      end
+    end
   end
 end

--- a/lib/synapse/service_discoverer.rb
+++ b/lib/synapse/service_discoverer.rb
@@ -1,0 +1,24 @@
+require_relative "./service_discoverer/base"
+require_relative "./service_discoverer/zookeeper"
+
+module Synapse
+  class ServiceDiscoverer
+
+    @discoverers = {
+      'base'=>BaseDiscoverer,
+      'zookeeper'=>ZookeeperDiscoverer,
+    }
+
+    # the method which actually dispatches watcher creation requests
+    def self.create(opts={}, static_services=[], synapse)
+      raise ArgumentError, "Missing discovery method when trying to create discoverer" \
+        unless opts.key?('method')
+
+      discovery_method = opts['method']
+      raise ArgumentError, "Invalid discovery method #{discovery_method}" \
+        unless @discoverers.key?(discovery_method)
+
+      return @discoverers[discovery_method].new(opts, static_services, synapse)
+    end
+  end
+end

--- a/lib/synapse/service_discoverer/base.rb
+++ b/lib/synapse/service_discoverer/base.rb
@@ -1,0 +1,74 @@
+require_relative './config_fetcher'
+
+module Synapse
+  class BaseDiscoverer
+    attr_reader :services
+
+    def initialize(opts={}, static_services=[], synapse)
+      super()
+
+      @synapse = synapse
+      @opts = opts
+      @static_services = static_services
+
+      @services = []
+      @discovered_services = []
+
+      raise ArgumentError, "Missing config fetcher" \
+        unless @opts.has_key?('fetcher')
+
+      @config_fetcher = create_config_fetcher(opts['fetcher'])
+
+      validate_discovery_opts
+    end
+
+    # this should be overridden to actually start your discoverer
+    def start
+      log.info "synapse: starting stub discoverer; this means doing nothing at all!"
+    end
+
+    # this should be overridden to do a health check of the discoverer
+    def ping?
+      true
+    end
+
+    private
+    def validate_discovery_opts
+      raise ArgumentError, "invalid discovery method '#{@opts['method']}' for base discoverer" \
+        unless @opts['method'] == 'base'
+
+      log.warn "synapse: warning: a stub discoverer is pretty useless"
+    end
+
+    def create_config_fetcher(opts)
+      return ConfigFetcher.create(opts)
+    end
+
+    def update_service_watchers
+
+      # Clean up dead services
+      @services.each do |serviceName, watcher|
+        if @discovered_services.index(serviceName).nil?
+          @services.delete(serviceName)
+        end
+      end
+
+      # Run through the discovered services and add any new ones
+      @discovered_services.each do |serviceName|
+
+        # Do we already know about this?
+        if (not @services.key?(serviceName)) and
+           @static_services.index(serviceName).nil?
+          # No - we haven't seen this. Fetch the config
+          begin
+            cfg = @config_fetcher.fetch serviceName
+            @services[serviceName] = cfg
+          rescue => e
+            # If something goes wrong just log it and ignore. No need to crash
+            log.error "synapse: Error fetching config for service #{serviceName}:\n#{e.inspect}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/synapse/service_discoverer/config_fetcher.rb
+++ b/lib/synapse/service_discoverer/config_fetcher.rb
@@ -1,0 +1,25 @@
+require_relative "./config_fetcher/base"
+require_relative "./config_fetcher/s3"
+
+module Synapse
+  class ConfigFetcher
+
+    @fetchers = {
+      'base'=>BaseFetcher,
+      's3'=>S3Fetcher,
+    }
+
+    # the method which actually dispatches watcher creation requests
+    def self.create(opts)
+
+      raise ArgumentError, "Missing fetcher method when trying to create config fetcher" \
+        unless opts.has_key?('method')
+
+      fetcher_method = opts['method']
+      raise ArgumentError, "Invalid fetcher method #{fetcher_method}" \
+        unless @fetchers.has_key?(fetcher_method)
+
+      return @fetchers[fetcher_method].new(opts)
+    end
+  end
+end

--- a/lib/synapse/service_discoverer/config_fetcher/base.rb
+++ b/lib/synapse/service_discoverer/config_fetcher/base.rb
@@ -1,0 +1,34 @@
+module Synapse
+  class BaseFetcher
+    def initialize(opts={})
+      @opts = opts
+
+      validate_fetcher_opts
+    end
+
+    def fetch(service)
+      log.warn "synapse: stub fetcher fetching - doing nothing!"
+    end
+
+    private
+    def validate_fetcher_opts
+      raise ArgumentError, "invalid method '#{@opts['method']}' for base fetcher" \
+        unless @opts['method'] == 'base'
+
+      log.warn "synapse: warning: a stub fetcher is pretty useless"
+    end
+
+    def apply_default_fields(config, service)
+      # If we don't have a discovery method but a default one is passed in the opts then
+      # add it
+      if (!config.key?('discovery')) and @opts.key?('default_discovery')
+        config['discovery'] = @opts['default_discovery']
+
+        # We may need to replace the service name in the path (if there is a path)
+        if config['discovery'].key?('path')
+          config['discovery']['path'] = config['discovery']['path'].sub('%SERVICE_NAME%', service)
+        end
+      end
+    end
+  end
+end

--- a/lib/synapse/service_discoverer/config_fetcher/s3.rb
+++ b/lib/synapse/service_discoverer/config_fetcher/s3.rb
@@ -1,0 +1,55 @@
+require_relative './base'
+
+require 'aws-sdk'
+require 'yaml'
+require 'json'
+
+module Synapse
+  class S3Fetcher < BaseFetcher
+    def initialize(opts)
+      super opts
+
+      # Setup our AWS connection
+      s3 = AWS::S3.new(YAML.load_file(@opts['credentials']))
+      @config_bucket = s3.buckets[@opts['bucket']]
+
+      raise ArgumentError, "#{@opts['bucket']} doesn't exist" \
+        unless @config_bucket.exists?
+
+    end
+
+    def fetch(service)
+      confFile = @config_bucket.objects[service]
+      service_conf = nil
+      if confFile.exists?
+
+        # Try and parse the config
+        begin
+          conf = JSON.parse(confFile.read)
+        rescue JSON::ParserError => e
+          raise "config file #{service} is not json:\n#{e.inspect}"
+        end
+
+        raise "config does not have a synapse section" unless conf.key?('synapse')
+
+        service_conf = conf['synapse']
+
+        apply_default_fields(service_conf, service)
+      else
+        raise "Cannot find config for #{service}"
+      end
+
+      return service_conf
+    end
+
+    private
+    def validate_fetcher_opts
+      raise ArgumentError, "invalid method '#{@opts['method']}' for s3 fetcher" \
+        unless @opts['method'] == 's3'
+      raise ArgumentError, "missing or invalid bucket for s3 config fetcher" \
+        unless @opts['bucket']
+      raise ArgumentError, "missing or invalid credentials for s3 config fetcher" \
+        unless @opts['credentials']
+    end
+  end
+end

--- a/lib/synapse/service_discoverer/zookeeper.rb
+++ b/lib/synapse/service_discoverer/zookeeper.rb
@@ -1,0 +1,82 @@
+require_relative "./base"
+
+require 'zk'
+
+module Synapse
+  class ZookeeperDiscoverer < BaseDiscoverer
+
+    def start
+
+      @services = {}
+
+      zk_hosts = @opts['hosts'].shuffle.join(',')
+
+      log.info "synapse: starting ZK discoverer @ hosts: #{zk_hosts}, path: #{@opts['path']}"
+
+      @zk = ZK.new(zk_hosts)
+
+      # call the callback to bootstrap the process
+      watcher_callback.call
+    end
+
+    def ping?
+      @zk.ping?
+    end
+
+    private
+    def validate_discovery_opts
+      raise ArgumentError, "invalid discovery method #{@opts['method']}" \
+        unless @opts['method'] == 'zookeeper'
+      raise ArgumentError, "missing or invalid zookeeper host for zookeeper service discoverer" \
+        unless @opts['hosts']
+      raise ArgumentError, "invalid zookeeper path for zookeeper service discoverer" \
+        unless @opts['path']
+    end
+
+    # helper method that ensures that the discovery path exists
+    def create(path)
+      log.debug "synapse: creating ZK path: #{path}"
+      # recurse if the parent node does not exist
+      create File.dirname(path) unless @zk.exists? File.dirname(path)
+      @zk.create(path, ignore: :node_exists)
+    end
+
+    # find the current services at the discovery path; sets @services
+    def discover
+      log.info "synapse: discovering services via zookeeperat #{@opts['path']}"
+
+      @discovered_services = []
+
+      begin
+        @zk.children(@opts['path'], :watch => true).map do |name|
+          log.debug "synapse: discovered service #{name}"
+          @discovered_services << name
+        end
+      rescue ZK::Exceptions::NoNode
+        # the path must exist, otherwise watch callbacks will not work
+        create(@opts['path'])
+        retry
+      end
+    end
+
+    # sets up zookeeper callbacks if the data at the discovery path changes
+    def watch
+      @watcher.unsubscribe if defined? @watcher
+      @watcher = @zk.register(@opts['path'], &watcher_callback)
+    end
+
+    # handles the event that a watched path has changed in zookeeper
+    def watcher_callback
+      @callback ||= Proc.new do |event|
+        # Set new watcher
+        watch
+        # Rediscover
+        discover
+        # Update watchers
+        update_service_watchers
+        # send a message to calling class to reconfigure
+        @synapse.reconfigure!
+      end
+    end
+  end
+end

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
+  gem.add_runtime_dependency "aws-sdk", "~> 1.25.0"
 
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "pry"


### PR DESCRIPTION
This is a bit of a speculative PR

I've been integrating nerve/synapse into a [mesos](http://mesos.apache.org) cluster. Essentially I want to setup a cluster that I can distribute a number of services across and have automatic TCP routing such that if I declare that a service listens on port A, I can visit port A on any server in the cluster and get routed to an instance of the service, wherever it happens to live.

Combining nerve and synapse seems like a good choice for doing this, however I ran into a bit of a problem - you have to configure the synapse services up front. This was less than ideal because I don't want to have to go and reconfigure each instance of synapse individually every time I introduce a new service. Ideally what would happen is that synapse discovers that a new service has been deployed, it goes and fetches the config from somewhere and reloads itself with the new service.

This is what this PR attempts to do.

I've introduced two new components - a Service Discoverer and a Config Fetcher (not my finest hour when it comes to inventing names…). The Service Discoverer is responsible for discovering which services are in play and should be routed to. The Config Fetcher is responsible for fetching the config for new/unknown services.

At the moment I've just got a zookeeper discoverer and an S3 fetcher (the config is placed in the S3) but it looks like it is working quite well, and others can be added at any time.

Here is an example of a new `config.json` to enable this functionality

    {
      "services": {}
      "haproxy": {
        ...
      },
      "service_discoverer": {
        "method": "zookeeper",
        "hosts": [
          "10.1.2.2:2181",
          "10.1.2.3:2181",
          "10.1.2.4:2181"
        ],
        "path": "/smartstack/services",
        "fetcher": {
          "method": "s3",
          "credentials": "/opt/smartstack/aws_credentials.yml",
          "bucket": "service-config",
          "default_discovery": {
            "method": "zookeeper",
            "hosts": [
              "10.1.2.2:2181",
              "10.1.2.3:2181",
              "10.1.2.4:2181"
            ],
            "path": "/smartstack/services/%SERVICE_NAME%/services"
          }
        }
      }
    }

and here is a config file that would be stored on the S3 and fetched

    {
      "synapse": {
        "haproxy": {
          "port": 4400,
          "server_options": "check inter 2s rise 3 fall 2",
          "listen": [
            "mode http",
            "option httpchk /ping"
          ]
        }
      },
      "nerve": {
        "check_interval": 1,
        "checks": [
          {
            "type": "http",
            "uri": "/ping",
            "timeout": 1,
            "rise": 1,
            "fall": 1
          }
        ]
      }
    }

I'm not sure this code is production ready yet, but would be interested to know whether you'd be interested in having something like this in the core code?