### PR TITLE
allow override of listening address

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ The `haproxy` section of the config file has the following options:
 * `do_reloads`: whether or not Synapse will reload HAProxy (default to `true`)
 * `global`: options listed here will be written into the `global` section of the HAProxy config
 * `defaults`: options listed here will be written into the `defaults` section of the HAProxy config
+* `bind_address`: force HAProxy to listen  on this address (default is localhost)
+
+Note that a non-default `bind_address` can be dangerous: it is up to you to ensure that HAProxy will not attempt to bind an address:port combination that is not already in use by one of your services.
 
 ## Contributing
 

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -619,7 +619,7 @@ module Synapse
       stanza = [
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-        "\tbind localhost:#{watcher.haproxy['port']}",
+        "\tbind #{@opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
         "\tdefault_backend #{watcher.name}"
       ]
     end


### PR DESCRIPTION
If, for instance, one wanted to have a pool of dedicated haproxy servers that
handled queries for other hosts, it would help to be able to listen on ports
other than localhost.

Default to the expected behavior.
