### PR TITLE
Add service watchers method

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ end
 3. Implement the `start` and `validate_discovery_opts` methods
 4. Implement whatever additional methods your discovery requires
 5. This can now be used in the synapse config as
+
 ```json
 {"services":
     "proddb": {

--- a/README.md
+++ b/README.md
@@ -213,13 +213,16 @@ Note that a non-default `bind_address` can be dangerous: it is up to you to ensu
 
 If you'd like to create a new service watcher:
 
-1. Create a file for your watcher in `service_watcher` dir
-2. Use the following template:
+Use the following template:
 ```ruby
-require 'synapse/service_watcher/base'
+require 'synapse/service_watcher
 
 module Synapse
   class NewWatcher < BaseWatcher
+
+    # add this custom watcher so it can be used in configs
+    Synapse::ServiceWatcher.add_service_watcher('my_watcher_name', self.class)
+
     def start
       # write code which begins running service discovery
     end
@@ -234,6 +237,17 @@ end
 
 3. Implement the `start` and `validate_discovery_opts` methods
 4. Implement whatever additional methods your discovery requires
+5. This can now be used in the synapse config as
+```json
+{"services":
+    "proddb": {
+      "discovery": {
+        "method": "my_watcher_name",
+		"module": "module/name",
+		"foo": "bar"
+      },
+...
+```
 
 When your watcher detects a list of new backends, they should be written to `@backends`.
 You should then call `@synapse.configure` to force synapse to update the HAProxy config.

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -30,9 +30,8 @@ module Synapse
       discovery_method = opts['discovery']['method']
 
       unless @watchers.has_key?(discovery_method)
-        if m = opts['discovery']['module']
-          require m
-        end
+        m = opts['discovery']['module'] ? opts['discovery']['module'] : "synapse-watcher-#{discovery_method}"
+        require m
       end
 
       raise ArgumentError, "Invalid discovery method #{discovery_method}" \

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -15,6 +15,11 @@ module Synapse
       'docker' => DockerWatcher
     }
 
+    # allow users to extend watchers without hacking core
+    def self.add_service_watcher(key, klass)
+      @watchers[key] = klass
+    end
+
     # the method which actually dispatches watcher creation requests
     def self.create(name, opts, synapse)
       opts['name'] = name
@@ -23,6 +28,13 @@ module Synapse
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
+
+      unless @watchers.has_key?(discovery_method)
+        if m = opts['discovery']['module']
+          require m
+        end
+      end
+
       raise ArgumentError, "Invalid discovery method #{discovery_method}" \
         unless @watchers.has_key?(discovery_method)
 

--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -6,6 +6,9 @@ require 'resolv'
 
 module Synapse
   class DnsWatcher < BaseWatcher
+
+    Synapse::ServiceWatcher.add_service_watcher('dns', self.class)
+
     include Logging
     def start
       @check_interval = @discovery['check_interval'] || 30.0

--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -3,6 +3,9 @@ require 'docker'
 
 module Synapse
   class DockerWatcher < BaseWatcher
+
+    Synapse::ServiceWatcher.add_service_watcher('docker', self.class)
+
     def start
       @check_interval = @discovery['check_interval'] || 15.0
       @watcher = Thread.new do

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -2,6 +2,9 @@ require "synapse/service_watcher/base"
 
 module Synapse
   class EC2Watcher < BaseWatcher
+
+    Synapse::ServiceWatcher.add_service_watcher('ec2tag', self.class)
+
     def start
       # connect to ec2
       # find all servers whose @discovery['tag_name'] matches @discovery['tag_value']

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -5,6 +5,9 @@ require 'zk'
 
 module Synapse
   class ZookeeperWatcher < BaseWatcher
+
+    Synapse::ServiceWatcher.add_service_watcher('zookeeper', self.class)
+
     include Logging
     def start
       zk_hosts = @discovery['hosts'].shuffle.join(',')


### PR DESCRIPTION
This allows a user to add additional service watchers without hacking core.