### PR TITLE
The base service watcher uses the logging mixin

### DIFF
--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -1,5 +1,8 @@
+require 'synapse/log'
+
 module Synapse
   class BaseWatcher
+    include Logging
     attr_reader :name, :backends, :haproxy
 
     def initialize(opts={}, synapse)

--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -1,12 +1,10 @@
 require "synapse/service_watcher/base"
-require "synapse/log"
 
 require 'thread'
 require 'resolv'
 
 module Synapse
   class DnsWatcher < BaseWatcher
-    include Logging
     def start
       @check_interval = @discovery['check_interval'] || 30.0
       @nameserver = @discovery['nameserver']

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -1,11 +1,9 @@
 require "synapse/service_watcher/base"
-require "synapse/log"
 
 require 'zk'
 
 module Synapse
   class ZookeeperWatcher < BaseWatcher
-    include Logging
     def start
       zk_hosts = @discovery['hosts'].shuffle.join(',')
 


### PR DESCRIPTION
Push it down into base.rb, so that it's available everywhere. This fixes the docker and DNS service watchers
