### PR TITLE
Fix discovery when some containers have no forwarded ports

### DIFF
--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -50,6 +50,24 @@ module Synapse
       end
     end
 
+    def rewrite_container_ports(ports)
+      pairs = []
+      if ports.is_a?(String)
+        # "Ports" comes through (as of 0.6.5) as a string like "0.0.0.0:49153->6379/tcp, 0.0.0.0:49153->6379/tcp"
+        # Convert string to a map of container port to host port: {"7000"->"49158", "6379": "49159"}
+        pairs = ports.split(", ").collect do |v|
+          pair = v.split('->')
+          [ pair[1].rpartition("/").first, pair[0].rpartition(":").last ]
+        end
+      elsif ports.is_a?(Array)
+        # New style API, ports is an array of hashes, with numeric values (or nil if no ports forwarded)
+        pairs = ports.collect do |v|
+          [v['PrivatePort'].to_s, v['PublicPort'].to_s]
+        end
+      end
+      Hash[pairs]
+    end
+
     def containers
       backends = @discovery['servers'].map do |server|
         Docker.url = "http://#{server['host']}:#{server['port'] || 4243}"
@@ -60,20 +78,7 @@ module Synapse
           next []
         end
         cnts.each do |cnt|
-          pairs = nil
-          if cnt["Ports"].is_a?(String)
-            # "Ports" comes through (as of 0.6.5) as a string like "0.0.0.0:49153->6379/tcp, 0.0.0.0:49153->6379/tcp"
-            # Convert string to a map of container port to host port: {"7000"->"49158", "6379": "49159"}
-            pairs = cnt["Ports"].split(", ").collect do |v|
-              pair = v.split('->')
-              [ pair[1].rpartition("/").first, pair[0].rpartition(":").last ]
-            end
-          else
-            pairs = cnt["Ports"].collect do |v|
-              [v['PrivatePort'].to_s, v['PublicPort'].to_s]
-            end
-          end
-          cnt["Ports"] = Hash[pairs]
+          cnt['Ports'] = rewrite_container_ports cnt['Ports']
         end
         # Discover containers that match the image/port we're interested in
         cnts = cnts.find_all do |cnt|

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -92,6 +92,20 @@ describe Synapse::DockerWatcher do
     end
   end
 
+  context "rewrite_container_ports tests" do
+    it 'doesnt break if Ports => nil' do
+        subject.send(:rewrite_container_ports, nil)
+    end
+    it 'works for old style port mappings' do
+      expect(subject.send(:rewrite_container_ports, "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp")).to \
+        eql({'6379' => '49153', '6390' => '49154'})
+    end
+    it 'works for new style port mappings' do
+      expect(subject.send(:rewrite_container_ports, [{'PrivatePort' => 6379, 'PublicPort' => 49153}, {'PublicPort' => 49154, 'PrivatePort' => 6390}])).to \
+        eql({'6379' => '49153', '6390' => '49154'})
+    end
+  end
+
   context "container discovery tests" do
     before(:each) do
       getter = double()


### PR DESCRIPTION
In the new API, docker can return nil in the JSON to indicate a container
has no ports forwarded. This notably happens when you're using the 'docker build'
command, and breaks synapse's discovery for the duration.

If you have a long running container with no ports forwarded, then
it's just always broken.

This fixes that bug and breaks out rewrite_container_ports into it's own
method as it's complex enough to justify it. Tests are added for the
3 (old/new/nil) cases that this method deals with
