### PR TITLE
Use YAML::SyntaxError since ParseError does not exist under Psyck Yaml

### DIFF
--- a/bin/synapse
+++ b/bin/synapse
@@ -37,7 +37,7 @@ def parseconfig(filename)
     raise ArgumentError, "config file does not exist:\n#{e.inspect}"
   rescue Errno::EACCES => e
     raise ArgumentError, "could not open config file:\n#{e.inspect}"
-  rescue YAML::ParseError => e
+  rescue YAML::SyntaxError => e
     raise "config file #{filename} is not yaml:\n#{e.inspect}"
   end
   return c.to_ruby


### PR DESCRIPTION
implementations.

Running the synapse binary gives:

```
> synapse
/Users/jbellegarde/src/synapse/bin/synapse:40:in `rescue in parseconfig': uninitialized constant Psych::ParseError (NameError)
        from /Users/jbellegarde/src/synapse/bin/synapse:34:in `parseconfig'
        from /Users/jbellegarde/src/synapse/bin/synapse:46:in `<top (required)>'
        from .bin/synapse:16:in `load'
        from .bin/synapse:16:in `<main>'

```

YAML is an alias for Psych. Psych has SyntaxError instead of  the Sick's ParseError. 
