### PR TITLE
Add support for pushing data to udp services.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     synapse (0.9.1)
       docker-api (~> 1.7.2)
+      eventmachine (~> 1.0.3)
       zk (~> 1.9.2)
 
 GEM
@@ -11,16 +12,19 @@ GEM
     archive-tar-minitar (0.5.2)
     coderay (1.0.9)
     diff-lcs (1.2.4)
-    docker-api (1.7.3)
+    docker-api (1.7.6)
       archive-tar-minitar
       excon (>= 0.28)
       json
-    excon (0.30.0)
+    eventmachine (1.0.3)
+    excon (0.32.1)
     json (1.8.1)
     little-plugger (1.1.3)
-    logging (1.7.2)
+    logging (1.8.2)
       little-plugger (>= 1.1.3)
+      multi_json (>= 1.8.4)
     method_source (0.8.2)
+    multi_json (1.9.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -37,8 +41,8 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.3)
     slop (3.4.6)
-    zk (1.9.3)
-      logging (~> 1.7.2)
+    zk (1.9.4)
+      logging (~> 1.8.2)
       zookeeper (~> 1.4.0)
     zookeeper (1.4.8)
 

--- a/lib/synapse/udp_forwarders.rb
+++ b/lib/synapse/udp_forwarders.rb
@@ -1,0 +1,93 @@
+require 'socket'
+require 'rubygems'
+require 'eventmachine'
+
+module Synapse
+  class UDPServer < EM::Connection
+    def initialize(remote)
+      @remote = remote
+    end
+
+    def receive_data(data)
+      host, port = @remote.get
+      relay = UDPSocket.new
+      relay.send(data, 0, host, port)
+    end
+  end
+
+  # wrap up the host and port so we can update the
+  # running server. also need to ensure atomic
+  # access to host and port pair to prevent race
+  # conditions with backends changing at the same time
+  # that requests are being forwarded.
+  class Remote
+    attr_reader :host, :port
+
+    def initialize(host, port)
+      @host = host
+      @port = port
+      @mutex = Mutex.new
+    end
+
+    def get
+      hostt = portt = nil
+      @mutex.synchronize do
+        hostt = host
+        portt = port
+      end
+      [hostt,portt]
+    end
+
+    def update(host, port)
+      @mutex.synchronize do
+        @host = host
+        @port = port
+      end
+    end
+  end
+
+  class UDPForwarder
+    def initialize(from_port)
+      @from_port = from_port
+      @thread = nil
+      @remote = nil # shared between this object and the UDPServer instance
+    end
+
+    def update(backends)
+      return if backends.empty?
+      # pick random backend and stick with it until there's an update
+      backend = backends.shuffle.first
+      host = backend['host']
+      port = backend['port']
+
+      if @thread
+        @remote.update(host, port)
+      else
+        @remote = Remote.new(host, port)
+        @thread = run
+      end
+    end
+
+
+    def run
+      Thread.new {
+         EM.run do
+          EM.open_datagram_socket('localhost', @from_port, UDPServer, @remote)
+        end
+      }
+    end
+  end
+
+  class UDPForwarders
+    def initialize
+      @forwarders = {}
+    end
+
+    def update_config(watchers)
+      watchers.each do |watcher|
+        @forwarders[watcher.name] ||= UDPForwarder.new(watcher.udp_forwarding['port'])
+        @forwarders[watcher.name].update(watcher.backends)
+      end
+    end
+  end
+end

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -20,11 +20,16 @@ describe Synapse::BaseWatcher do
     it('can at least construct') { expect { subject }.not_to raise_error }
   end
 
-  ['name', 'discovery', 'haproxy'].each do |to_remove|
+  ['name', 'discovery'].each do |to_remove|
     context "without #{to_remove} argument" do
       let(:args) { remove_arg to_remove }
       it('gots bang') { expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}") }
     end
+  end
+
+  context "without haproxy or udp_forwarding argument" do
+    let(:args) { remove_arg 'haproxy' }
+    it('has a proxy type') { expect { subject }.to raise_error(ArgumentError, "must have exactly one of haproxy or udp_forwarding") }
   end
 
   context "normal tests" do

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "docker-api", "~> 1.7.2"
+  gem.add_runtime_dependency "eventmachine", "~> 1.0.3"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"


### PR DESCRIPTION
Because HAProxy does not support udp, an alternative is required. This commit
adds an optional "udp_forwarding" section to the service level configuration.
The only configuration is a port, over which udp data will be forwarded to one
of the service's host:port combinations. Both "udp_forwarding" and "haproxy" cannot be present.

Some example use cases of this would be forwarding data to an external logging service or external monitoring services.

This branch does not support incoming udp data but that felt like a rare use case to me.