### PR TITLE
Support cookie-based sticky sessions

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1,5 +1,6 @@
 require 'synapse/log'
 require 'socket'
+require 'digest/md5'
 
 module Synapse
   class Haproxy
@@ -632,7 +633,9 @@ module Synapse
         config.map {|c| "\t#{c}"},
         watcher.backends.shuffle.map {|backend|
           backend_name = construct_name(backend)
-          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} #{watcher.haproxy['server_options']}" }
+          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} #{watcher.haproxy['server_options']}".
+            gsub('{md5cookie}', Digest::MD5.hexdigest(backend_name))
+        }
       ]
     end
 


### PR DESCRIPTION
Hey guys,

To have sticky sessions, we need to have a unique per server cookie content, per backend, ie.

```
backend somebackend
   cookie BALANCEID insert indirect
   server srv1 ipaddr:port cookie uniquename1 otheroptions
   server srv2 ipaddr:port cookie uniquename2 otheroptions
```

Currently there is no way to do this with synapse.
This patch allows to put a unique name as {md5cookie} in the configuration and generate the actual content.

practical usage:
- in listen options, add a line `cookie NAMEOFCOOKIE insert indirect` - or whatever other option you want
- in server_options, add `cookie {md5cookie}` before the other options (ie. before `check inter 5s fastinter 2s downinter 3s rise 3 fall 2`) or something like that.

That's all
