### PR TITLE
Fix a bug raising an error without shared_frontend.

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -557,7 +557,7 @@ module Synapse
           end
         end
       end
-      new_config << shared_frontend_lines.flatten
+      new_config << shared_frontend_lines.flatten if shared_frontend_lines
 
       log.debug "synapse: new haproxy config: #{new_config}"
       return new_config.flatten.join("\n")


### PR DESCRIPTION
Though shared_frontend is optional config, if shared_frontend option is not supplied, NoMethodError will be raised without this patch:

```
/vagrant/lib/synapse/haproxy.rb:560:in `generate_config': undefined method `flatten' for nil:NilClass (NoMethodError)
```
