### PR TITLE
Add `keep_default_servers` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ Each hash in that section has the following options:
 
 The `default_servers` list is used only when service discovery returns no servers.
 In that case, the service proxy will be created with the servers listed here.
-If you do not list any default servers, no proxy will be created.
+If you do not list any default servers, no proxy will be created.  The
+`default_servers` will also be used in addition to discovered servers if the
+`keep_default_servers` option is set.
 
 #### The `haproxy` Section ####
 

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -40,6 +40,8 @@ module Synapse
       @default_servers = opts['default_servers'] || []
       @backends = @default_servers
 
+      @keep_default_servers = opts['keep_default_servers'] || false
+
       # set a flag used to tell the watchers to exit
       # this is not used in every watcher
       @should_exit = false
@@ -90,6 +92,14 @@ module Synapse
         unless @discovery['method'] == 'base'
 
       log.warn "synapse: warning: a stub watcher with no default servers is pretty useless" if @default_servers.empty?
+    end
+
+    def set_backends(new_backends)
+      if @keep_default_servers
+        @backends = @default_servers + new_backends
+      else
+        @backends = new_backends
+      end
     end
   end
 end

--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -95,7 +95,7 @@ module Synapse
         end
       else
         log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
-        @backends = new_backends
+        set_backends(new_backends)
       end
       @synapse.reconfigure!
     end

--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -106,7 +106,7 @@ module Synapse
         end
       else
         log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
-        @backends = new_backends
+        set_backends(new_backends)
       end
       @synapse.reconfigure!
     end

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -88,7 +88,7 @@ module Synapse
         end
       else
         log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
-        @backends = new_backends
+        set_backends(new_backends)
       end
     end
 

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -41,6 +41,15 @@ describe Synapse::BaseWatcher do
     default_servers = ['server1', 'server2']
     let(:args) { testargs.merge({'default_servers' => default_servers}) }
     it('sets default backends to default_servers') { expect(subject.backends).to equal(default_servers) }
+
+    context "with keep_default_servers set" do
+      let(:args) { testargs.merge({'default_servers' => default_servers, 'keep_default_servers' => true}) }
+      let(:new_backends) { ['discovered1', 'discovered2'] }
+
+      it('keeps default_servers when setting backends') do
+        subject.send(:set_backends, new_backends)
+        expect(subject.backends).to eq(default_servers + new_backends)
+      end
+    end
   end
 end
-


### PR DESCRIPTION
Allows you to use the `default_servers` for a service in addition to discovered servers.
