### PR TITLE
Fix error when no shared frontends are defined.

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -557,7 +557,10 @@ module Synapse
           end
         end
       end
-      new_config << shared_frontend_lines.flatten
+
+      unless shared_frontend_lines.nil?
+        new_config << shared_frontend_lines.flatten
+      end
 
       log.debug "synapse: new haproxy config: #{new_config}"
       return new_config.flatten.join("\n")


### PR DESCRIPTION
Fix the following error which occurs when no shared frontends are defined:

```
synapse/lib/synapse/haproxy.rb:560:in `generate_config': undefined method `flatten' for nil:NilClass (NoMethodError)
        from synapse/lib/synapse/haproxy.rb:534:in `update_config'
        from synapse/lib/synapse.rb:45:in `block in run'
        from synapse/lib/synapse.rb:37:in `loop'
        from synapse/lib/synapse.rb:37:in `run'
        from synapse/bin/synapse:60:in `<top (required)>'
        from synapse/binstubs/synapse:16:in `load'
        from synapse/binstubs/synapse:16:in `<main>'
```
