### PR TITLE
Fix Config/RbConfig related warning in tests.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,13 +6,13 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require "#{File.dirname(__FILE__)}/../lib/synapse"
 require 'pry'
-require 'support/config'
+require 'support/configuration'
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.include Config
+  config.include Configuration
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -1,6 +1,6 @@
 require "yaml"
 
-module Config
+module Configuration
 
   def config
     @config ||= YAML::load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'minimum.conf.yaml'))


### PR DESCRIPTION
Hello, just a small tweak to silence "Use RbConfig instead of obsolete and deprecated Config." generated by the spec_helper. It's not _really_ RbConfig we want anyway, remove any confusion.
