### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/airbnb/synapse.png?branch=master)](https://travis-ci.org/airbnb/synapse)
-[![Inline docs](http://inch-pages.github.io/github/airbnb/synapse.png)](http://inch-pages.github.io/github/airbnb/synapse)
+[![Inline docs](http://inch-ci.org/github/airbnb/synapse.png)](http://inch-ci.org/github/airbnb/synapse)
 
 # Synapse #
 


### PR DESCRIPTION
Hi there,

this patch updates the URL of the docs badge in your README. Inch's badges will be served from it's own CI service http://inch-ci.org in the future and I will slowly retire the old [Inch Pages project](http://inch-pages.github.io/). 

With the new service, people can [add projects straight from the homepage](http://inch-ci.org/) and also [configure a webhook to rebuild](http://inch-ci.org/howto/webhook) their badges auto-magically :star2:

I am so happy that Inch and Inch Pages were so well received in the community and that I am now able to keep [my promise](http://trivelop.de/2014/02/24/visibility-of-documentation/) to deliver a real, [open source](https://github.com/inch-ci) web service for the badges.

P.S. I have not written an announcement or anything for this, yet. **But**: Everybody who reads this is invited to add their projects to the site. Please help me find the last bugs, so I can start writing the "Introducing Inch CI" blog post :wink:
