### PR TITLE
[haproxy] always add a cookie to the server

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -664,7 +664,8 @@ module Synapse
         config.map {|c| "\t#{c}"},
         watcher.backends.shuffle.map {|backend|
           backend_name = construct_name(backend)
-          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} #{watcher.haproxy['server_options']}" }
+          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} " \
+            "cookie #{backend_name} #{watcher.haproxy['server_options']}" }
       ]
     end
 


### PR DESCRIPTION
This makes it easier to do session persistence based on a cookie. Without an accompanying
`cookie` setting in the backend, this change has no effect, as confirmed by
Willie in this mailing list post:

http://marc.info/?l=haproxy&m=140312462018915&w=2
