### PR TITLE
Allow service-specific bind_addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ If you do not list any default servers, no proxy will be created.  The
 This section is its own hash, which should contain the following keys:
 
 * `port`: the port (on localhost) where HAProxy will listen for connections to the service. If this is omitted, only a backend stanza (and no frontend stanza) will be generated for this service; you'll need to get traffic to your service yourself via the `shared_frontend` or manual frontends in `extra_sections`
+* `bind_address`: the IP address the frontend will listen on. This will override a bind_address specified globally below.
 * `server_port_override`: the port that discovered servers listen on; you should specify this if your discovery mechanism only discovers names or addresses (like the DNS watcher). If the discovery method discovers a port along with hostnames (like the zookeeper watcher) this option may be left out, but will be used in preference if given.
 * `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out.
 * `frontend`: additional lines passed to the HAProxy config in the `frontend` stanza of this service

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -646,10 +646,12 @@ module Synapse
         return []
       end
 
+      bind_address = (watcher.haproxy['bind_address'] || @opts['bind_address'] || 'localhost')
+
       stanza = [
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-        "\tbind #{@opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
+        "\tbind #{bind_address}:#{watcher.haproxy['port']}",
         "\tdefault_backend #{watcher.name}"
       ]
     end


### PR DESCRIPTION
While one can specify bind_address in the haproxy section of the config, this applies to all frontends globally. I would like to be able to override this per frontend, by specifying it with the port in the haproxy section of my service thus:

```
      "haproxy": {
        "bind_address": "1.2.3.4",
        "port": "80",
        ....
```