### PR TITLE
slaves_as_backup: mark the slave nodes as backup nodes in haproxy

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -664,7 +664,7 @@ module Synapse
         config.map {|c| "\t#{c}"},
         watcher.backends.shuffle.map {|backend|
           backend_name = construct_name(backend)
-          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} " \
+          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} #{' backup' if backend['backup']} " \
             "cookie #{backend_name} #{watcher.haproxy['server_options']}" }
       ]
     end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -69,11 +69,11 @@ module Synapse
     def backends
       if @leader_election
         if @backends.all?{|b| b.key?('id') && b['id']}
-          smallest = @backends.sort_by{ |b| b['id']}.first
+          @backends.sort_by{ |b| b['id']}.first['backup'] = false
           log.debug "synapse: leader election chose one of #{@backends.count} backends " \
             "(#{smallest['host']}:#{smallest['port']} with id #{smallest['id']})"
 
-          return [smallest]
+          return @backends
         elsif (Time.now - @leader_last_warn) > LEADER_WARN_INTERVAL
           log.warn "synapse: service #{@name}: leader election failed; not all backends include an id"
           @leader_last_warn = Time.now

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -65,7 +65,7 @@ module Synapse
           numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
 
           log.debug "synapse: discovered backend #{name} at #{host}:#{server_port} for service #{@name}"
-          new_backends << { 'name' => name, 'host' => host, 'port' => server_port, 'id' => numeric_id}
+          new_backends << { 'name' => name, 'host' => host, 'port' => server_port, 'id' => numeric_id, 'backup' => @leader_election}
         end
       end
 


### PR DESCRIPTION
This way the slave nodes will be used as backup nodes if the master node fails while zookeeper is unreachable by synapse.