### PR TITLE
Make AWS region, access key, and secret key settings optional.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.11.1)
+    strava-synapse (0.11.3)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7.2)
       zk (~> 1.9.4)
@@ -10,7 +10,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
-    aws-sdk (1.47.0)
+    aws-sdk (1.56.0)
+      aws-sdk-v1 (= 1.56.0)
+    aws-sdk-v1 (1.56.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     coderay (1.0.9)
@@ -19,7 +21,7 @@ GEM
       archive-tar-minitar
       excon (>= 0.28)
       json
-    excon (0.38.0)
+    excon (0.40.0)
     ffi (1.9.3-java)
     json (1.8.1)
     json (1.8.1-java)
@@ -30,9 +32,9 @@ GEM
     method_source (0.8.2)
     mini_portile (0.6.0)
     multi_json (1.10.1)
-    nokogiri (1.6.2.1)
+    nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
-    nokogiri (1.6.2.1-java)
+    nokogiri (1.6.3.1-java)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -61,8 +63,8 @@ GEM
     zk (1.9.4)
       logging (~> 1.8.2)
       zookeeper (~> 1.4.0)
-    zookeeper (1.4.8)
-    zookeeper (1.4.8-java)
+    zookeeper (1.4.9)
+    zookeeper (1.4.9-java)
       slyphon-log4j (= 1.2.15)
       slyphon-zookeeper_jar (= 3.3.5)
 
@@ -75,4 +77,4 @@ DEPENDENCIES
   pry-nav
   rake
   rspec
-  synapse!
+  strava-synapse!

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -7,13 +7,13 @@ module Synapse
     attr_reader :check_interval
 
     def start
-      region = @discovery['aws_region'] || ENV['AWS_REGION']
+      region = @discovery['aws_region']
       log.info "Connecting to EC2 region: #{region}"
 
       @ec2 = AWS::EC2.new(
         region:            region,
-        access_key_id:     @discovery['aws_access_key_id']     || ENV['AWS_ACCESS_KEY_ID'],
-        secret_access_key: @discovery['aws_secret_access_key'] || ENV['AWS_SECRET_ACCESS_KEY'] )
+        access_key_id:     @discovery['aws_access_key_id'],
+        secret_access_key: @discovery['aws_secret_access_key'])
 
       @check_interval = @discovery['check_interval'] || 15.0
 
@@ -43,13 +43,6 @@ module Synapse
 
       unless @haproxy['server_port_override'].match(/^\d+$/)
         raise ArgumentError, "Invalid server_port_override value"
-      end
-
-      # Required, but can use well-known environment variables.
-      %w[aws_access_key_id aws_secret_access_key aws_region].each do |attr|
-        unless (@discovery[attr] || ENV[attr.upcase])
-          raise ArgumentError, "Missing #{attr} option or #{attr.upcase} environment variable"
-        end
       end
     end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.11.1"
+  VERSION = "0.11.3"
 end

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -86,21 +86,24 @@ describe Synapse::EC2Watcher do
     end
 
     context 'when missing arguments' do
-      it 'complains if aws_region is missing' do
+      it 'does not complain if aws_region is missing' do
         expect {
           Synapse::EC2Watcher.new(remove_discovery_arg('aws_region'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_region/)
+        }.to_not raise_error(ArgumentError)
       end
-      it 'complains if aws_access_key_id is missing' do
+
+      it 'does not complain if aws_access_key_id is missing' do
         expect {
           Synapse::EC2Watcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_access_key_id/)
+        }.to_not raise_error(ArgumentError)
       end
-      it 'complains if aws_secret_access_key is missing' do
+
+      it 'does not complain if aws_secret_access_key is missing' do
         expect {
           Synapse::EC2Watcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_secret_access_key/)
+        }.to_not raise_error(ArgumentError)
       end
+
       it 'complains if server_port_override is missing' do
         expect {
           Synapse::EC2Watcher.new(remove_haproxy_arg('server_port_override'), mock_synapse)

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'synapse/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "synapse"
+  gem.name          = "strava-synapse"
   gem.version       = Synapse::VERSION
   gem.authors       = ["Martin Rhoads"]
   gem.email         = ["martin.rhoads@airbnb.com"]


### PR DESCRIPTION
The AWS SDK is smart enough to figure out the region, access key, and secret
key if the user has not specified them. It looks for the AWS_REGION environment
variable itself. It also uses a credential provider that attempts to locate
credentials from 1) AWS.config, 2) environment variables, 3) the EC2 metadata
service. Using the built-in configuration functionality of the SDK is required
for instances that get credentials based on IAM roles and have no access keys
on the instance.