### PR TITLE
Consider only running instances and memoize AWS calls.

### DIFF
--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -137,8 +137,9 @@ describe Synapse::EC2Watcher do
 
         subject.ec2.should_receive(:instances).and_return(instance_collection)
 
-        instance_collection.should_receive(:tagged).and_return(instance_collection)
-        instance_collection.should_receive(:tagged_values).and_return(instance_collection)
+        instance_collection.should_receive(:tagged).with('foo').and_return(instance_collection)
+        instance_collection.should_receive(:tagged_values).with('bar').and_return(instance_collection)
+        instance_collection.should_receive(:select).and_return(instance_collection)
 
         subject.send(:instances_with_tags, 'foo', 'bar')
       end


### PR DESCRIPTION
It doesn't make sense to retrieve starting, stopping, stopped, and terminated instances
and include them on the server list. The `memoize` block ensures that results
from requests are remembered, avoiding redundant calls to retrieve instance
details.
