### PR TITLE
Marathon Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ be used in preference to the `AWS_` environment variables.
 * `aws_secret_access_key`: AWS secret key or set `AWS_SECRET_ACCESS_KEY` in the environment.
 * `aws_region`: AWS region (i.e. `us-east-1`) or set `AWS_REGION` in the environment.
 
+##### Marathon #####
+
+This watcher retrieves a list of [Marathon](https://github.com/mesosphere/marathon) managed tasks via
+Marathon's [HTTP API](https://github.com/mesosphere/marathon/blob/master/REST.md).
+It takes the following options:
+
+* `method`: marathon
+* `hostname`: a list of servers running Marathon as a daemon. Format is a URL.
+* `app_id`: Marathon application ID. This is case-sensitive.
+* `port_index`: which of the allocated ports to connect to. Default is 0.
+* `check_interval`: how often to poll the Marathon API on each server. Default is 15s.
+
 #### Listing Default Servers ####
 
 You may list a number of default servers providing a service.

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,6 +4,7 @@ require "synapse/service_watcher/ec2tag"
 require "synapse/service_watcher/dns"
 require "synapse/service_watcher/docker"
 require "synapse/service_watcher/zookeeper_dns"
+require "synapse/service_watcher/marathon"
 
 module Synapse
   class ServiceWatcher
@@ -15,6 +16,7 @@ module Synapse
       'dns' => DnsWatcher,
       'docker' => DockerWatcher,
       'zookeeper_dns' => ZookeeperDnsWatcher,
+      'marathon' => MarathonWatcher,
     }
 
     # the method which actually dispatches watcher creation requests

--- a/lib/synapse/service_watcher/marathon.rb
+++ b/lib/synapse/service_watcher/marathon.rb
@@ -1,0 +1,110 @@
+require 'synapse/service_watcher/base'
+require 'marathon'
+
+module Synapse
+  class MarathonWatcher < BaseWatcher
+
+    attr_reader :check_interval
+    attr_reader :port_index
+
+    def start
+      @marathon = Marathon::Client.new(
+        @discovery['hostname'],
+        @discovery['username'],
+        @discovery['password']
+      )
+
+      @check_interval = @discovery['check_interval'] || 15.0
+
+      @watcher = Thread.new do
+        watch
+      end
+    end
+
+    private
+    def validate_discovery_opts
+      raise ArgumentError, "invalid discovery method #{@discovery['method']}" \
+        unless @discovery['method'] == 'marathon'
+      raise ArgumentError, "non-empty hostname is required for service #{@name}" \
+        if @discovery['hostname'].nil? or @discovery['hostname'].empty?
+      raise ArgumentError, "non-empty app_id is required for service #{@name}" \
+        if @discovery['app_id'].nil? or @discovery['app_id'].empty?
+      raise ArgumentError, "Invalid port_index value" \
+        if not @discovery['port_index'].nil? and not @discovery['port_index'].empty? and not @discovery['port_index'].match(/^\d+$/)
+
+      @port_index = @discovery['port_index'].to_i || 0
+    end
+
+    def watch
+      last_backends = []
+      until @should_exit
+        begin
+          start = Time.now
+          current_backends = discover_instances
+
+          if last_backends != current_backends
+            log.info "synapse: marathon watcher backends have changed."
+            last_backends = current_backends
+            configure_backends(current_backends)
+          else
+            log.info "synapse: marathon watcher backends are unchanged."
+          end
+
+          sleep_until_next_check(start)
+        rescue Exception => e
+          log.warn "synapse: error in marathon watcher thread: #{e.inspect}"
+          log.warn e.backtrace
+        end
+      end
+
+      log.info "synapse: marathon watcher exited successfully"
+    end
+
+    def sleep_until_next_check(start_time)
+      sleep_time = @check_interval - (Time.now - start_time)
+      if sleep_time > 0.0
+        sleep(sleep_time)
+      end
+    end
+
+    def discover_instances
+        tasks = list_app_tasks(@discovery['app_id'])
+
+        new_backends = []
+
+        tasks.each do |task|
+          new_backends << {
+            'name' => task.id,
+            'host' => task.host,
+            'port' => task.ports[@port_index]
+          }
+        end
+
+        new_backends
+    end
+
+    def list_app_tasks(app_id)
+      @marathon.list_tasks(app_id).parsed_response['tasks']
+    end
+
+    def configure_backends(new_backends)
+      if new_backends.empty?
+        if @default_servers.empty?
+          log.warn "synapse: no backends and no default servers for service #{@name};" \
+            " using previous backends: #{@backends.inspect}"
+        else
+          log.warn "synapse: no backends for service #{@name};" \
+            " using default servers: #{@default_servers.inspect}"
+          @backends = @default_servers
+        end
+      else
+        log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
+        set_backends(new_backends)
+      end
+      reconfigure!
+    end
+
+  end
+
+end
+

--- a/lib/synapse/service_watcher/marathon.rb
+++ b/lib/synapse/service_watcher/marathon.rb
@@ -74,9 +74,9 @@ module Synapse
 
         tasks.each do |task|
           new_backends << {
-            'name' => task.id,
-            'host' => task.host,
-            'port' => task.ports[@port_index]
+            'name' => task['id'],
+            'host' => task['host'],
+            'port' => task['ports'][@port_index]
           }
         end
 
@@ -84,7 +84,7 @@ module Synapse
     end
 
     def list_app_tasks(app_id)
-      @marathon.list_tasks(app_id).parsed_response['tasks']
+      @marathon.list_tasks(app_id).parsed_response[app_id]
     end
 
     def configure_backends(new_backends)

--- a/lib/synapse/service_watcher/marathon.rb
+++ b/lib/synapse/service_watcher/marathon.rb
@@ -83,8 +83,14 @@ module Synapse
         new_backends
     end
 
-    def list_app_tasks(app_id)
-      @marathon.list_tasks(app_id).parsed_response[app_id]
+   def list_app_tasks(app_id)
+      response = @marathon.list_tasks(app_id)
+      if response.success?
+        response.parsed_response[app_id]
+      else
+        log.warn "synapse: error polling Marathon host #{@discovery['hostname']}: #{response.error}"
+        []
+      end
     end
 
     def configure_backends(new_backends)

--- a/lib/synapse/service_watcher/marathon.rb
+++ b/lib/synapse/service_watcher/marathon.rb
@@ -43,11 +43,11 @@ module Synapse
           current_backends = discover_instances
 
           if last_backends != current_backends
-            log.info "synapse: marathon watcher backends have changed."
+            log.debug "synapse: marathon watcher backends have changed."
             last_backends = current_backends
             configure_backends(current_backends)
           else
-            log.info "synapse: marathon watcher backends are unchanged."
+            log.debug "synapse: marathon watcher backends are unchanged."
           end
 
           sleep_until_next_check(start)
@@ -68,7 +68,7 @@ module Synapse
     end
 
     def discover_instances
-        tasks = list_app_tasks(@discovery['app_id'])
+        tasks = list_app_tasks(@discovery['app_id']) || []
 
         new_backends = []
 

--- a/spec/lib/synapse/service_watcher_marathon_spec.rb
+++ b/spec/lib/synapse/service_watcher_marathon_spec.rb
@@ -1,0 +1,171 @@
+require 'spec_helper'
+require 'logging'
+
+class Synapse::MarathonWatcher
+  attr_reader   :synapse
+  attr_accessor :default_servers, :marathon
+end
+
+class FakeMarathonTask
+  def id
+    @id ||= fake_address
+  end
+
+  def host
+    @host ||= "marathon-#{id.gsub('.', '-')}.example.com"
+  end
+
+  def ports
+    @ports = []
+  end
+
+  def fake_address
+    4.times.map { (0...254).to_a.shuffle.pop.to_s }.join('.')
+  end
+end
+
+describe Synapse::MarathonWatcher do
+  let(:mock_synapse) { double }
+  subject { Synapse::MarathonWatcher.new(basic_config, mock_synapse) }
+
+  let(:basic_config) do
+    { 'name' => 'marathontest',
+      'haproxy' => {
+        'port' => '8080',
+        'server_port_override' => '8081'
+      },
+      "discovery" => {
+        "method" => "marathon",
+        "hostname" => "marathon-server",
+        "app_id" => "app_id",
+        "port_index" => "1"
+      }
+    }
+  end
+
+  before(:all) do
+    # Clean up ENV so we don't inherit any actual Marathon config.
+    %w[MARATHON_HOST].each { |k| ENV.delete(k) }
+  end
+
+  def remove_discovery_arg(name)
+    args = basic_config.clone
+    args['discovery'].delete name
+    args
+  end
+
+  describe '#new' do
+    let(:args) { basic_config }
+
+    it 'instantiates cleanly with basic config' do
+      expect { subject }.not_to raise_error
+    end
+
+    context 'when missing arguments' do
+      it 'complains if hostname is missing' do
+        expect {
+          Synapse::MarathonWatcher.new(remove_discovery_arg('hostname'), mock_synapse)
+        }.to raise_error(ArgumentError, /non-empty hostname/)
+      end
+      it 'complains if app_id is missing' do
+        expect {
+          Synapse::MarathonWatcher.new(remove_discovery_arg('app_id'), mock_synapse)
+        }.to raise_error(ArgumentError, /non-empty app_id/)
+      end
+    end
+
+    context 'sane defaults' do
+      it 'defaults to port_index 0 if not specified' do
+          expect {
+            Synapse::MarathonWatcher.new(remove_discovery_arg('port_index'), mock_synapse)
+          }.to_not raise_error
+      end
+    end
+  end
+
+  context "instance discovery" do
+    let(:instance1) { FakeMarathonTask.new }
+    let(:instance2) { FakeMarathonTask.new }
+
+    context 'using the Marathon API' do
+      let(:marathon_client) { double('Marathon::Client') }
+      let(:task_list) { double('Marathon::Maration::Response') }
+
+      before do
+        subject.marathon = marathon_client
+      end
+
+      it 'fetches tasks' do
+        expect(subject.marathon).to receive(:list_tasks).and_return(task_list)
+        expect(task_list).to receive(:parsed_response).and_return({ 'tasks' => [instance1, instance2] })
+
+        subject.send(:list_app_tasks, 'foo')
+      end
+    end
+
+    context 'returned backend data structure' do
+      before do
+        allow(subject).to receive(:list_app_tasks).and_return([instance1, instance2])
+      end
+
+      let(:backends) { subject.send(:discover_instances) }
+
+      it 'returns an Array of backend name/host/port Hashes' do
+        expect(backends.all? {|b| %w[name host port].each {|k| b.has_key?(k) }}).to be true
+      end
+
+    end
+
+    context 'returned instance fields' do
+      before do
+        allow(subject).to receive(:list_app_tasks).and_return([instance1])
+      end
+
+      let(:backend) { subject.send(:discover_instances).pop }
+
+      it "returns a task's host as the hostname" do
+        expect( backend['host'] ).to eq instance1.host
+      end
+
+      it "returns a task's id as the server name" do
+        expect( backend['name'] ).to eq instance1.id
+      end
+    end
+  end
+
+  context "configure_backends tests" do
+    let(:backend1) { { 'name' => 'foo',  'host' => 'foo.backend.tld',  'port' => '123' } }
+    let(:backend2) { { 'name' => 'bar',  'host' => 'bar.backend.tld',  'port' => '456' } }
+    let(:fallback) { { 'name' => 'fall', 'host' => 'fall.backend.tld', 'port' => '789' } }
+
+    before(:each) do
+      expect(subject.synapse).to receive(:'reconfigure!').at_least(:once)
+    end
+
+    it 'runs' do
+      expect { subject.send(:configure_backends, []) }.not_to raise_error
+    end
+
+    it 'sets backends correctly' do
+      subject.send(:configure_backends, [ backend1, backend2 ])
+      expect(subject.backends).to eq([ backend1, backend2 ])
+    end
+
+    it 'resets to default backends if no instances are found' do
+      subject.default_servers = [ fallback ]
+      subject.send(:configure_backends, [ backend1 ])
+      expect(subject.backends).to eq([ backend1 ])
+      subject.send(:configure_backends, [])
+      expect(subject.backends).to eq([ fallback ])
+    end
+
+    it 'does not reset to default backends if there are no default backends' do
+      subject.default_servers = []
+      subject.send(:configure_backends, [ backend1 ])
+      expect(subject.backends).to eq([ backend1 ])
+      subject.send(:configure_backends, [])
+      expect(subject.backends).to eq([ backend1 ])
+    end
+  end
+end
+

--- a/spec/lib/synapse/service_watcher_marathon_spec.rb
+++ b/spec/lib/synapse/service_watcher_marathon_spec.rb
@@ -79,9 +79,20 @@ describe Synapse::MarathonWatcher do
 
       it 'fetches tasks' do
         expect(subject.marathon).to receive(:list_tasks).and_return(task_list)
+        expect(task_list).to receive(:success?).and_return(true)
         expect(task_list).to receive(:parsed_response).and_return({ 'tasks' => [instance1, instance2] })
 
         subject.send(:list_app_tasks, 'foo')
+      end
+
+      it 'handles client errors' do
+        expect(subject.marathon).to receive(:list_tasks).and_return(task_list)
+        expect(task_list).to receive(:success?).and_return(false)
+        expect(task_list).to receive(:error).and_return({ 'error' => 'message' })
+
+        tasks = subject.send(:list_app_tasks, 'foo')
+
+        expect( tasks ).to be_empty
       end
     end
 

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "aws-sdk", "~> 1.39"
   gem.add_runtime_dependency "docker-api", "~> 1.7.2"
+  gem.add_runtime_dependency "marathon_client", "~> 0.2.3"
   gem.add_runtime_dependency "zk", "~> 1.9.4"
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
This adds a service watcher that uses data from the Marathon REST API V2 to locate services. It's based on a combination of the Docker and EC2 watchers.