### PR TITLE
Fix to not include a cookie in TCP mode.

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -664,8 +664,10 @@ module Synapse
         config.map {|c| "\t#{c}"},
         watcher.backends.shuffle.map {|backend|
           backend_name = construct_name(backend)
-          "\tserver #{backend_name} #{backend['host']}:#{backend['port']} " \
-            "cookie #{backend_name} #{watcher.haproxy['server_options']}" }
+          b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}"
+          b = "#{b} cookie #{backend_name}" unless config.include?('mode tcp')
+          b = "#{b} #{watcher.haproxy['server_options']}"
+          b }
       ]
     end
 

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -5,9 +5,28 @@ class MockWatcher; end;
 describe Synapse::Haproxy do
   subject { Synapse::Haproxy.new(config['haproxy']) }
 
-  it 'updating the config' do
+  let(:mockwatcher) do
     mockWatcher = double(Synapse::ServiceWatcher)
-    subject.should_receive(:generate_config)
-    subject.update_config([mockWatcher])
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    backends = [{ 'host' => 'somehost', 'port' => '5555'}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2"})
+    mockWatcher
   end
+
+  it 'updating the config' do
+    expect(subject).to receive(:generate_config)
+    subject.update_config([mockwatcher])
+  end
+
+  it 'generates backend stanza' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
+  end
+
+  it 'generates backend stanza without cookies for tcp mode' do
+    mockConfig = ['mode tcp']
+    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", ["\tmode tcp"], ["\tserver somehost:5555 somehost:5555 check inter 2000 rise 3 fall 2"]])
+  end
+
 end


### PR DESCRIPTION
b7098382 added a cookie always, however this only works in HTTP mode.
Remove/disable this automatic addition when we're in TCP mode.
