### PR TITLE
Feature/addressable ips

### DIFF
--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -103,25 +103,19 @@ module Synapse
             request = '/containers/' + id + '/json'
             begin
               Docker.url = "http://#{server['host']}:#{server['port'] || 4243}"
-              response = Docker::Util.parse_json("[" + Docker.connection.get(request, {})+ "]")
+              response = Docker::Util.parse_json('[' + Docker.connection.get(request, {})+ ']')
             rescue => an_error
               log.warn "synapse: error inspecting container : #{an_error.inspect}"
               next []
             end
         
-            the_name = ""
-            the_host = ""
-            response.each do |info|
-              the_name = info["Config"]["Hostname"]
-              the_host = info["NetworkSettings"]["IPAddress"]
-            end
-        
+            # Nothing to loop through here, so just look at the response and get what we want
             {
-              'name' => the_name,
-              'host' => the_host,
-              'port' => cnt["Ports"][@discovery["container_port"].to_s()]
+              'name' => response[0]['Config']['Hostname'],
+              'host' => response[0]['NetworkSettings']['IPAddress'],
+              'port' => cnt['Ports'][@discovery['container_port'].to_s()]
             }
-            
+
           end
 
         # If the IP isn't addressable, then we pick our host and server from the config and use the Private Port.


### PR DESCRIPTION
These changes provide a way to update the HAProxy config for docker containers that are on addressable IPs (i.e IP addresses reachable on the network / outside of the local docker host).  The change allows you to provide a discovery setting of "addressable_ip" for docker discovered services as shown below:

``` JSON
"services": {
    "local-nodes": {
      "discovery": {
        "method": "docker",
        "addressable_ip": "true",
        "servers": [
          {
            "name": "localhost",
            "host": "192.168.224.2",
            "port": 4243
          }
    ],
    "container_port": 8000,
        "image_name": "local/testapp"
      },
      "haproxy": {
        "port": 9091,
      }
```

This change then looks up the actual IP address of the docker container instead of using the docker host and then uses the private port of the service.  The change does not affect the previous functionality - both services with non-addressable IPs and those with addressable IPs are properly written to the HAProxy config.  So a synapse config file that looks like this:

``` JSON
{
  "services": {
    "local-nodes": {
      "discovery": {
        "method": "docker",
        "addressable_ip": "true",
        "servers": [
          {
            "name": "localhost",
            "host": "192.168.224.2",
            "port": 4243
          }
    ],
    "container_port": 8000,
        "image_name": "local/testapp"
      },
      "haproxy": {
        "port": 9091,

      }

    },
    "remote-nodes":{
      "discovery": {
        "method": "docker",
        "servers": [
          {
            "name": "cconnell3",
            "host": "192.168.222.153",
        "port": 4243
      }
        ],
      "container_port": 8000,
        "image_name": "local/testapp"
      },
      "haproxy": {
        "port": 9091,

      }

    },
    "proxy-clients": {
      "discovery": {
        "method": "docker",
        "addressable_ip": "true",
        "servers": [
          {
            "name": "localhost",
            "host": "192.168.224.2",
            "port": 4243
      }
        ],
        "container_port": 9090,
        "image_name": "local/proxy-node"
      },
      "haproxy": {
        "port": 9090,

      }

    },

  },
"haproxy": {
    "reload_command": "systemctl reload haproxy.service",
    "config_file_path": "/etc/haproxy/haproxy.cfg",
    "do_writes": true,
    "do_reloads": true,
    "bind_address": "*",
    "global": [
      "daemon",
      "maxconn 4096",
    ],
    "defaults": [
      "maxconn  2000",
      "timeout  connect 5s",
      "timeout  client  1m",
      "timeout  server  1m",
      "mode http",
    ],
  }
}
```

will result in an haproxy config like:

```
# auto-generated by synapse at 2014-09-03 16:04:10 -0400

global
        daemon
    maxconn 4096
defaults
        maxconn  2000
        timeout  connect 5s
        timeout  client  1m
        timeout  server  1m
        mode http

frontend local-nodes
        bind *:9091
        default_backend local-nodes

backend local-nodes
        server 192.168.224.19:8000_27f8db643d74 192.168.224.19:8000 cookie 192.168.224.19:8000_27f8db643d74
        server 192.168.224.22:8000_c5dd48c1adac 192.168.224.22:8000 cookie 192.168.224.22:8000_c5dd48c1adac
        server 192.168.224.18:8000_df6616b4e4af 192.168.224.18:8000 cookie 192.168.224.18:8000_df6616b4e4af

frontend remote-nodes
        bind *:9091
        default_backend remote-nodes

backend remote-nodes
        server 192.168.222.153:49155_cconnell3 192.168.222.153:49155 cookie 192.168.222.153:49155_cconnell3
        server 192.168.222.153:49154_cconnell3 192.168.222.153:49154 cookie 192.168.222.153:49154_cconnell3
        server 192.168.222.153:49153_cconnell3 192.168.222.153:49153 cookie 192.168.222.153:49153_cconnell3

frontend proxy-clients
        bind *:9090
        default_backend proxy-clients

backend proxy-clients
        server 192.168.224.28:9090_sel-node-6 192.168.224.28:9090 cookie 192.168.224.28:9090_sel-node-6
        server 192.168.224.29:9090_sel-node-7 192.168.224.29:9090 cookie 192.168.224.29:9090_sel-node-7
        server 192.168.224.25:9090_sel-node-4 192.168.224.25:9090 cookie 192.168.224.25:9090_sel-node-4
        server 192.168.224.30:9090_sel-node-8 192.168.224.30:9090 cookie 192.168.224.30:9090_sel-node-8
        server 192.168.224.24:9090_sel-node-3 192.168.224.24:9090 cookie 192.168.224.24:9090_sel-node-3
        server 192.168.224.27:9090_sel-node-5 192.168.224.27:9090 cookie 192.168.224.27:9090_sel-node-5
```
