### PR TITLE
Filter out containers with unmapped ports

### DIFF
--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -80,10 +80,11 @@ module Synapse
         cnts.each do |cnt|
           cnt['Ports'] = rewrite_container_ports cnt['Ports']
         end
-        # Discover containers that match the image/port we're interested in
+        # Discover containers that match the image/port we're interested in and have the port mapped to the host
         cnts = cnts.find_all do |cnt|
           cnt["Image"].rpartition(":").first == @discovery["image_name"] \
-            and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+            and cnt["Ports"].has_key?(@discovery["container_port"].to_s()) \
+            and cnt["Ports"][@discovery["container_port"].to_s()].length > 0
         end
         cnts.map do |cnt|
           {

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -116,9 +116,9 @@ describe Synapse::DockerWatcher do
     it('has a sane uri') { subject.send(:containers); expect(Docker.url).to eql('http://server1.local:4243') }
 
     context 'old style port mappings' do
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:tagname"}] }
       context 'works for one container' do
-        let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:tagname"}] }
-        it do 
+        it do
           expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
           expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
          end
@@ -138,6 +138,12 @@ describe Synapse::DockerWatcher do
         expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
         expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
       end
+
+      it 'filters out containers with unmapped ports' do
+        test_docker_data = docker_data + [{"Ports" => [{'PrivatePort' => 6379}], "Image" => "mycool/image:unmapped"}]
+        expect(Docker::Util).to receive(:parse_json).and_return(test_docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
+      end
     end
 
     context 'filters out wrong images' do
@@ -149,4 +155,3 @@ describe Synapse::DockerWatcher do
     end
   end
 end
-


### PR DESCRIPTION
This bit us when running one-off containers on our docker hosts (to run scripts, debug problems, etc.). Synapse would pick up the container because the image name and the private port matched, but the missing public port would cause it to generate an invalid haproxy config file and crash.

This fixes that by adding a simple check that the public port is present when deciding which containers to consider adding as backends.

It only does this for new-style port mappings because I can't find any docs on what the old-style port mappings looked like in this situation, nor is it clear that you could even prevent an exposed port from being mapped back when that version of the remote API was in use.