### PR TITLE
Adding optional image_tag param to docker watcher  

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The `haproxy` section of the config file has the following options:
 * `defaults`: options listed here will be written into the `defaults` section of the HAProxy config
 * `extra_sections`: additional, manually-configured `frontend`, `backend`, or `listen` stanzas
 * `bind_address`: force HAProxy to listen on this address (default is localhost)
-* `shared_fronted`: (OPTIONAL) additional lines passed to the HAProxy config used to configure a shared HTTP frontend (see below)
+* `shared_frontend`: (OPTIONAL) additional lines passed to the HAProxy config used to configure a shared HTTP frontend (see below)
 
 Note that a non-default `bind_address` can be dangerous.
 If you configure an `address:port` combination that is already in use on the system, haproxy will fail to start.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ It takes the following options:
 * `method`: docker
 * `servers`: a list of servers running docker as a daemon. Format is `{"name":"...", "host": "..."[, port: 4243]}`
 * `image_name`: find containers running this image
+* `image_tag`: (OPTIONAL) if specified, only find containers running the above image with this tag
 * `container_port`: find containers forwarding this port
 * `check_interval`: how often to poll the docker API on each server. Default is 15s.
 

--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -20,6 +20,8 @@ module Synapse
         if @discovery['image_name'].nil? or @discovery['image_name'].empty?
       raise ArgumentError, "container_port required" \
         if @discovery['container_port'].nil?
+      raise ArgumentError, "image_tag cannot be empty" \
+        if @discovery['image_tag'] != nil and @discovery['image_tag'].empty?
     end
 
     def watch
@@ -81,9 +83,16 @@ module Synapse
           cnt['Ports'] = rewrite_container_ports cnt['Ports']
         end
         # Discover containers that match the image/port we're interested in
-        cnts = cnts.find_all do |cnt|
-          cnt["Image"].rpartition(":").first == @discovery["image_name"] \
-            and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+        if @discovery["image_tag"]
+          cnts = cnts.find_all do |cnt|
+            cnt["Image"] == @discovery["image_name"] + ":" + @discovery["image_tag"] \
+              and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+          end
+        else
+          cnts = cnts.find_all do |cnt|
+            cnt["Image"].rpartition(":").first == @discovery["image_name"] \
+              and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+          end
         end
         cnts.map do |cnt|
           {

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -147,6 +147,23 @@ describe Synapse::DockerWatcher do
         expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
       end
     end
+
+    context 'matches any tag' do
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:mycooltag"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "mycool/image:wrong_tagname"}] }
+      it do
+        expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"},{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49155"}])
+      end
+    end
+
+    context 'filters out wrong image tags' do
+      let(:testargs) { add_arg('image_tag', 'mycooltag') }
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:mycooltag"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "mycool/image:wrong_tagname"}] }
+      it do
+        expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
+      end
+    end
   end
 end
 


### PR DESCRIPTION
To explicitly discover only containers running image_name:image_tag. I've found this to be quite valuable in the deploy cycle as I can bring up containers and move them to the tag defined in synapse config when I'm ready for them to be discovered. README updated to reflect.