### PR TITLE
AWS credentials are not required when 'use_iam_profile' is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ be used in preference to the `AWS_` environment variables.
 * `aws_secret_access_key`: AWS secret key or set `AWS_SECRET_ACCESS_KEY` in the environment.
 * `aws_region`: AWS region (i.e. `us-east-1`) or set `AWS_REGION` in the environment.
 
+When launching an EC2 instance with an [IAM role and instance profile](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html), the aws-sdk will
+make API requests without having credentials supplied explicitly. If `use_iam_profile = true`
+is specified as an option, the `aws_access_key_id` and `aws_secret_access_key` options
+can be omitted.
+
+* `use_iam_profile`: If true, the IAM instance profile is used for credentials.
+
 #### Listing Default Servers ####
 
 You may list a number of default servers providing a service.

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -45,8 +45,10 @@ module Synapse
         raise ArgumentError, "Invalid server_port_override value"
       end
 
-      # Required, but can use well-known environment variables.
-      %w[aws_access_key_id aws_secret_access_key aws_region].each do |attr|
+      puts @discovery
+      aws_vars = %w[aws_region]
+      aws_vars += %w[aws_access_key_id aws_secret_access_key] unless @discovery['use_iam_profile']
+      aws_vars.each do |attr|
         unless (@discovery[attr] || ENV[attr.upcase])
           raise ArgumentError, "Missing #{attr} option or #{attr.upcase} environment variable"
         end

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -108,6 +108,22 @@ describe Synapse::EC2Watcher do
       end
     end
 
+    context 'when using iam profile' do
+      let(:iam_config) do
+        config = basic_config.clone
+        config['discovery']['use_iam_profile'] = true
+        config['discovery'].delete 'aws_access_key_id'
+        config['discovery'].delete 'aws_secret_access_key'
+        config
+      end
+
+      it 'does not complain if aws credentials are missing' do
+        expect {
+          Synapse::EC2Watcher.new(iam_config, mock_synapse)
+        }.not_to raise_error()
+      end
+    end
+
     context 'invalid data' do
       it 'complains if the haproxy server_port_override is not a number' do
           expect {


### PR DESCRIPTION
Similar to #84 except that
- `aws_region` continues to be validated (the aws-sdk will not auto-magically fill this in.)
- `use_iam_profile` is an explicit configuration option

