### PR TITLE
Backup nodes + httpchk

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ Each hash in that section has the following options:
 * `name`: a human-readable name for the default server; must be unique
 * `host`: the host or IP address of the server
 * `port`: the port where the service runs on the `host`
+* `backup` : boolean, use the server in backup mode
+* `httpchk` : boolean, use haproxy httpchk for this server, requires `"option httpchk /"` to be set under haproxy options
+* `chkport` : custom port for httpchk
 
 The `default_servers` list is used only when service discovery returns no servers.
 In that case, the service proxy will be created with the servers listed here.

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -717,7 +717,7 @@ module Synapse
         config.map {|c| "\t#{c}"},
         backends.keys.shuffle.map {|backend_name|
           backend = backends[backend_name]
-          b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}"
+          b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}#{' backup' if backend['backup']}#{' check port ' if backend['httpchk']}#{backend['chkport']}"
           b = "#{b} cookie #{backend_name}" unless config.include?('mode tcp')
           b = "#{b} #{watcher.haproxy['server_options']}"
           b = "#{b} disabled" unless backend['enabled']

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -715,8 +715,13 @@ module Synapse
       stanza = [
         "\nbackend #{watcher.name}",
         config.map {|c| "\t#{c}"},
+<<<<<<< HEAD
         backends.keys.shuffle.map {|backend_name|
           backend = backends[backend_name]
+=======
+        watcher.backends.shuffle.map {|backend|
+          backend_name = construct_name(backend)
+>>>>>>> Allow haproxy httpchk on a custom port
           b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}#{' backup' if backend['backup']}#{' check port ' if backend['httpchk']}#{backend['chkport']}"
           b = "#{b} cookie #{backend_name}" unless config.include?('mode tcp')
           b = "#{b} #{watcher.haproxy['server_options']}"

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -715,13 +715,8 @@ module Synapse
       stanza = [
         "\nbackend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-<<<<<<< HEAD
         backends.keys.shuffle.map {|backend_name|
           backend = backends[backend_name]
-=======
-        watcher.backends.shuffle.map {|backend|
-          backend_name = construct_name(backend)
->>>>>>> Allow haproxy httpchk on a custom port
           b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}#{' backup' if backend['backup']}#{' check port ' if backend['httpchk']}#{backend['chkport']}"
           b = "#{b} cookie #{backend_name}" unless config.include?('mode tcp')
           b = "#{b} #{watcher.haproxy['server_options']}"


### PR DESCRIPTION
This patch allows to set stub backends as `backup` and adds the ability to use the Haproxy `httpchk` option with custom check ports for those nodes.