### PR TITLE
watcher for Apache Aurora zookeeper announcements

### DIFF
--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,6 +4,7 @@ require "synapse/service_watcher/ec2tag"
 require "synapse/service_watcher/dns"
 require "synapse/service_watcher/docker"
 require "synapse/service_watcher/zookeeper_dns"
+require "synapse/service_watcher/zookeeper_aurora"
 
 module Synapse
   class ServiceWatcher
@@ -15,6 +16,7 @@ module Synapse
       'dns' => DnsWatcher,
       'docker' => DockerWatcher,
       'zookeeper_dns' => ZookeeperDnsWatcher,
+      'zookeeper_aurora' => ZookeeperAuroraWatcher
     }
 
     # the method which actually dispatches watcher creation requests

--- a/lib/synapse/service_watcher/zookeeper_aurora.rb
+++ b/lib/synapse/service_watcher/zookeeper_aurora.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+#
+# Variant of the Zookeeper service watcher that works with Apache Aurora
+# service announcements.
+#
+# Parameters:
+#   hosts: list of zookeeper hosts to query (List of Strings, required)
+#   path: "/path/to/serverset/in/zookeeper" (String, required)
+#   port_name: Named service endpoint (String, optional)
+#
+# If port_name is omitted, uses the default serviceEndpoint port.
+
+# zk node data looks like this:
+#
+# {
+#   "additionalEndpoints": {
+#     "aurora": {
+#       "host": "somehostname",
+#       "port": 31943
+#     },
+#     "http": {
+#       "host": "somehostname",
+#       "port": 31943
+#     },
+#     "otherport": {
+#       "host": "somehostname",
+#       "port": 31944
+#     }
+#   },
+#   "serviceEndpoint": {
+#     "host": "somehostname",
+#     "port": 31943
+#   },
+#   "shard": 0,
+#   "status": "ALIVE"
+# }
+#
+
+require 'synapse/service_watcher/zookeeper'
+
+module Synapse
+  # Watcher for Zookeeper announcements from Apache Aurora
+  class ZookeeperAuroraWatcher < Synapse::ZookeeperWatcher
+    def validate_discovery_opts
+      @discovery['method'] == 'zookeeper_aurora' ||
+        fail(ArgumentError,
+             "Invalid discovery method: #{@discovery['method']}")
+      @discovery['hosts'] ||
+        fail(ArgumentError,
+             "Missing or invalid zookeeper host for service #{@name}")
+      @discovery['path'] ||
+        fail(ArgumentError, "Invalid zookeeper path for service #{@name}")
+    end
+
+    def deserialize_service_instance(data)
+      log.debug 'Deserializing process data'
+      decoded = JSON.parse(data)
+
+      name = decoded['shard'].to_s ||
+        fail("Instance JSON data missing 'shard' key")
+
+      hostport = if @discovery['port_name']
+                   decoded['additionalEndpoints'][@discovery['port_name']] ||
+                     fail("Endpoint '#{@discovery['port_name']}' not found " \
+                          'in instance JSON data')
+                 else
+                   decoded['serviceEndpoint']
+                 end
+
+      host = hostport['host'] || fail("Instance JSON data missing 'host' key")
+      port = hostport['port'] || fail("Instance JSON data missing 'port' key")
+
+      [host, port, name]
+    end
+  end
+end


### PR DESCRIPTION
Aurora zookeeper serversets are comparable to what Nerve does, but Aurora uses a different json structure in the zookeeper nodes, and it has provisions for more than one advertised port for a service.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/airbnb/synapse/104)
<!-- Reviewable:end -->
