### PR TITLE
Latest rspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     coderay (1.0.9)
-    diff-lcs (1.2.4)
+    diff-lcs (1.2.5)
     docker-api (1.7.6)
       archive-tar-minitar
       excon (>= 0.28)
@@ -45,14 +45,18 @@ GEM
     pry-nav (0.2.3)
       pry (~> 0.9.10)
     rake (10.1.1)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.5)
-    rspec-expectations (2.14.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.3)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
     slop (3.4.6)
     slyphon-log4j (1.2.15)
     slyphon-zookeeper_jar (3.3.5-java)
@@ -74,5 +78,5 @@ DEPENDENCIES
   pry
   pry-nav
   rake
-  rspec
+  rspec (~> 3.1.0)
   synapse!

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -153,15 +153,17 @@ describe Synapse::EC2Watcher do
       let(:backends) { subject.send(:discover_instances) }
 
       it 'returns an Array of backend name/host/port Hashes' do
-
-        expect { backends.all? {|b| %w[name host port].each {|k| b.has_key?(k) }} }.to be_true
+        required_keys = %w[name host port]
+        expect(
+          backends.all?{|b| required_keys.each{|k| b.has_key?(k)}}
+        ).to be_truthy
       end
 
       it 'sets the backend port to server_port_override for all backends' do
         backends = subject.send(:discover_instances)
-        expect {
+        expect(
           backends.all? { |b| b['port'] == basic_config['haproxy']['server_port_override'] }
-        }.to be_true
+        ).to be_truthy
       end
     end
 

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -135,11 +135,11 @@ describe Synapse::EC2Watcher do
         # done remotely; breaking into separate calls would result in
         # unnecessary data being retrieved.
 
-        subject.ec2.should_receive(:instances).and_return(instance_collection)
+        expect(subject.ec2).to receive(:instances).and_return(instance_collection)
 
-        instance_collection.should_receive(:tagged).with('foo').and_return(instance_collection)
-        instance_collection.should_receive(:tagged_values).with('bar').and_return(instance_collection)
-        instance_collection.should_receive(:select).and_return(instance_collection)
+        expect(instance_collection).to receive(:tagged).with('foo').and_return(instance_collection)
+        expect(instance_collection).to receive(:tagged_values).with('bar').and_return(instance_collection)
+        expect(instance_collection).to receive(:select).and_return(instance_collection)
 
         subject.send(:instances_with_tags, 'foo', 'bar')
       end
@@ -147,7 +147,7 @@ describe Synapse::EC2Watcher do
 
     context 'returned backend data structure' do
       before do
-        subject.stub(:instances_with_tags).and_return([instance1, instance2])
+        allow(subject).to receive(:instances_with_tags).and_return([instance1, instance2])
       end
 
       let(:backends) { subject.send(:discover_instances) }
@@ -169,7 +169,7 @@ describe Synapse::EC2Watcher do
 
     context 'returned instance fields' do
       before do
-        subject.stub(:instances_with_tags).and_return([instance1])
+        allow(subject).to receive(:instances_with_tags).and_return([instance1])
       end
 
       let(:backend) { subject.send(:discover_instances).pop }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ require 'pry'
 require 'support/configuration'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.include Configuration

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,12 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.include Configuration
 
+  # verify every double we can think of
+  config.mock_with :rspec do |mocks|
+    mocks.verify_doubled_constant_names = true
+    mocks.verify_partial_doubles = true
+  end
+
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -1,9 +1,7 @@
 require "yaml"
 
 module Configuration
-
   def config
     @config ||= YAML::load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'minimum.conf.yaml'))
   end
-
 end

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "zk", "~> 1.9.4"
 
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "~> 3.1.0"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
 end


### PR DESCRIPTION
Switches synapse to using the latest rspec. We are currently getting a ton of synapse warnings when running specs, and that should be on the TODO list to fix in a future PR.

