### PR TITLE
Add optional image_tag param to docker watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ It takes the following options:
 * `method`: docker
 * `servers`: a list of servers running docker as a daemon. Format is `{"name":"...", "host": "..."[, port: 4243]}`
 * `image_name`: find containers running this image
+* `image_tag`: (OPTIONAL) if specified, only find containers running the above image with this tag
 * `container_port`: find containers forwarding this port
 * `check_interval`: how often to poll the docker API on each server. Default is 15s.
 

--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -20,6 +20,8 @@ module Synapse
         if @discovery['image_name'].nil? or @discovery['image_name'].empty?
       raise ArgumentError, "container_port required" \
         if @discovery['container_port'].nil?
+      raise ArgumentError, "image_tag cannot be empty" \
+        if @discovery['image_tag'] != nil and @discovery['image_tag'].empty?
     end
 
     def watch
@@ -81,9 +83,16 @@ module Synapse
           cnt['Ports'] = rewrite_container_ports cnt['Ports']
         end
         # Discover containers that match the image/port we're interested in
-        cnts = cnts.find_all do |cnt|
-          cnt["Image"].rpartition(":").first == @discovery["image_name"] \
-            and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+        if @discovery["image_tag"]
+          cnts = cnts.find_all do |cnt|
+            cnt["Image"] == @discovery["image_name"] + ":" + @discovery["image_tag"] \
+              and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+          end
+        else
+          cnts = cnts.find_all do |cnt|
+            cnt["Image"].rpartition(":").first == @discovery["image_name"] \
+              and cnt["Ports"].has_key?(@discovery["container_port"].to_s())
+          end
         end
         cnts.map do |cnt|
           {

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -7,7 +7,7 @@ end
 
 describe Synapse::DockerWatcher do
   let(:mocksynapse) { double() }
-  subject { Synapse::DockerWatcher.new(testargs, mocksynapse) }
+  subject { Synapse::DockerWatcher.new(args, mocksynapse) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'docker', 'servers' => [{'host' => 'server1.local', 'name' => 'mainserver'}], 'image_name' => 'mycool/image', 'container_port' => 6379 }, 'haproxy' => {} }}
   before(:each) do
     allow(subject.log).to receive(:warn)
@@ -21,10 +21,12 @@ describe Synapse::DockerWatcher do
   end
 
   context "can construct normally" do
+    let(:args) { testargs }
     it('can at least construct') { expect { subject }.not_to raise_error }
   end
 
   context "normal tests" do
+    let(:args) { testargs }
     it('starts a watcher thread') do
       watcher_mock = double()
       expect(Thread).to receive(:new).and_return(watcher_mock)
@@ -39,6 +41,7 @@ describe Synapse::DockerWatcher do
   end
 
   context "watch tests" do
+    let(:args) { testargs }
     before(:each) do
       expect(subject).to receive(:sleep_until_next_check) do |arg|
         subject.instance_variable_set('@should_exit', true)
@@ -56,6 +59,7 @@ describe Synapse::DockerWatcher do
     end
   end
   context "watch eats exceptions" do
+    let(:args) { testargs }
     it "blows up when finding containers" do
       expect(subject).to receive(:containers) do |arg|
         subject.instance_variable_set('@should_exit', true)
@@ -66,6 +70,7 @@ describe Synapse::DockerWatcher do
   end
 
   context "configure_backends tests" do
+    let(:args) { testargs }
     before(:each) do
       expect(subject.synapse).to receive(:'reconfigure!').at_least(:once)
     end
@@ -93,6 +98,7 @@ describe Synapse::DockerWatcher do
   end
 
   context "rewrite_container_ports tests" do
+    let(:args) { testargs }
     it 'doesnt break if Ports => nil' do
         subject.send(:rewrite_container_ports, nil)
     end
@@ -113,9 +119,13 @@ describe Synapse::DockerWatcher do
       expect(Docker).to receive(:connection).and_return(getter)
     end
 
-    it('has a sane uri') { subject.send(:containers); expect(Docker.url).to eql('http://server1.local:4243') }
+    context 'uri sane' do
+      let(:args) { testargs }
+      it('has a sane uri') { subject.send(:containers); expect(Docker.url).to eql('http://server1.local:4243') }
+    end
 
     context 'old style port mappings' do
+      let(:args) { testargs }
       context 'works for one container' do
         let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:tagname"}] }
         it do 
@@ -133,6 +143,7 @@ describe Synapse::DockerWatcher do
     end
 
     context 'new style port mappings' do
+      let(:args) { testargs }
       let(:docker_data) { [{"Ports" => [{'PrivatePort' => 6379, 'PublicPort' => 49153}, {'PublicPort' => 49154, 'PrivatePort' => 6390}], "Image" => "mycool/image:tagname"}] }
       it do
         expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
@@ -141,7 +152,26 @@ describe Synapse::DockerWatcher do
     end
 
     context 'filters out wrong images' do
+      let(:args) { testargs }
       let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:tagname"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "wrong/image:tagname"}] }
+      it do
+        expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
+      end
+    end
+
+    context 'matches any tag' do
+      let(:args) { testargs }
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:mycooltag"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "mycool/image:wrong_tagname"}] }
+      it do
+        expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"},{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49155"}])
+      end
+    end
+
+    context 'filters out wrong image tags' do
+      let(:args) { add_arg('image_tag', 'mycooltag') }
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image:mycooltag"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "mycool/image:wrong_tagname"}] }
       it do
         expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
         expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])


### PR DESCRIPTION
Rebase of #96 with minor changes.

Add param to explicitly discover only containers running image_name:image_tag. I've found this to be quite valuable in the deploy cycle as I can bring up containers and move them to the tag defined in synapse config when I'm ready for them to be discovered.
