### PR TITLE
ec2tag watcher improvements

### DIFF
--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -45,11 +45,14 @@ class Synapse::ServiceWatcher
         raise ArgumentError, "Invalid server_port_override value"
       end
 
-      # Required, but can use well-known environment variables.
-      %w[aws_access_key_id aws_secret_access_key aws_region].each do |attr|
-        unless (@discovery[attr] || ENV[attr.upcase])
-          raise ArgumentError, "Missing #{attr} option or #{attr.upcase} environment variable"
-        end
+      # aws region is optional in the SDK, aws will use a default value if not provided
+      unless @discovery['aws_region'] || ENV['AWS_REGION']
+        log.info "aws region is missing, will use default"
+      end
+      # access key id & secret are optional, might be using IAM instance profile for credentials
+      unless ((@discovery['aws_access_key_id'] || ENV['aws_access_key_id']) \
+              && (@discovery['aws_secret_access_key'] || ENV['aws_secret_access_key'] ))
+        log.info "aws access key id & secret not set in config or env variables for service #{name}, will attempt to use IAM instance profile"
       end
     end
 

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -63,10 +63,11 @@ class Synapse::ServiceWatcher
           if set_backends(discover_instances)
             log.info "synapse: ec2tag watcher backends have changed."
           end
-          sleep_until_next_check(start)
         rescue Exception => e
           log.warn "synapse: error in ec2tag watcher thread: #{e.inspect}"
           log.warn e.backtrace
+        ensure
+          sleep_until_next_check(start)
         end
       end
 

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -41,7 +41,7 @@ class Synapse::ServiceWatcher
           "Missing server_port_override for service #{@name} - which port are backends listening on?"
       end
 
-      unless @haproxy['server_port_override'].match(/^\d+$/)
+      unless @haproxy['server_port_override'].to_s.match(/^\d+$/)
         raise ArgumentError, "Invalid server_port_override value"
       end
 

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -87,20 +87,20 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     end
 
     context 'when missing arguments' do
-      it 'complains if aws_region is missing' do
+      it 'does not break if aws_region is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_region/)
+          Synapse::ServiceWatcher::EC2Watcher.new(remove_discovery_arg('aws_region'), mock_synapse)
+        }.not_to raise_error
       end
-      it 'complains if aws_access_key_id is missing' do
+      it 'does not break if aws_access_key_id is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_access_key_id/)
+          Synapse::ServiceWatcher::EC2Watcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
+        }.not_to raise_error
       end
-      it 'complains if aws_secret_access_key is missing' do
+      it 'does not break if aws_secret_access_key is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
-        }.to raise_error(ArgumentError, /Missing aws_secret_access_key/)
+          Synapse::ServiceWatcher::EC2Watcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
+        }.not_to raise_error
       end
       it 'complains if server_port_override is missing' do
         expect {


### PR DESCRIPTION
- don't require aws credential args, to allow using iam instance profiles
- fix bug where if an exception was raised in the watch method the sleep period got skipped. Better to wait the usual interval before retrying than to start running the failing discover instances method every few ms if something is wrong.