### PR TITLE
Allow pluggable watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,29 +342,5 @@ Non-HTTP backends such as MySQL or RabbitMQ will obviously continue to need thei
 
 ### Creating a Service Watcher ###
 
-If you'd like to create a new service watcher:
-
-1. Create a file for your watcher in `service_watcher` dir
-2. Use the following template:
-```ruby
-require 'synapse/service_watcher/base'
-
-module Synapse
-  class NewWatcher < BaseWatcher
-    def start
-      # write code which begins running service discovery
-    end
-
-    private
-    def validate_discovery_opts
-      # here, validate any required options in @discovery
-    end
-  end
-end
-```
-
-3. Implement the `start` and `validate_discovery_opts` methods
-4. Implement whatever additional methods your discovery requires
-
-When your watcher detects a list of new backends, you should call `set_backends` to
-store the new backends and update the HAProxy config.
+See the Service Watcher [README](lib/synapse/service_watcher/README.md) for
+how to add new Service Watchers.

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -1,18 +1,18 @@
-require "synapse/version"
-require "synapse/service_watcher/base"
-require "synapse/haproxy"
-require "synapse/file_output"
-require "synapse/service_watcher"
-require "synapse/log"
-
 require 'logger'
 require 'json'
 
-include Synapse
+require "synapse/version"
+require "synapse/log"
+require "synapse/haproxy"
+require "synapse/file_output"
+require "synapse/service_watcher"
+
 
 module Synapse
   class Synapse
+
     include Logging
+
     def initialize(opts={})
       # create the service watchers for all our services
       raise "specify a list of services to connect in the config" unless opts.has_key?('services')

--- a/lib/synapse/file_output.rb
+++ b/lib/synapse/file_output.rb
@@ -1,4 +1,3 @@
-require 'synapse/log'
 require 'fileutils'
 require 'tempfile'
 

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1,6 +1,5 @@
 require 'fileutils'
 require 'json'
-require 'synapse/log'
 require 'socket'
 
 module Synapse

--- a/lib/synapse/service_watcher/README.md
+++ b/lib/synapse/service_watcher/README.md
@@ -1,0 +1,58 @@
+Please, do not submit pull requests with new watchers, as Synapse and Nerve
+both support a plugin system for adding watchers and reporters respectively.
+
+## Watcher Classes
+
+Watchers are the piece of Synapse that watch an external service registry
+and reflect those changes in the local HAProxy state. Watchers should look
+like:
+
+```
+require "synapse/service\_watcher/base"
+
+module Synapse::ServiceWatcher
+  class MyWatcher < BaseWatcher
+  ...
+  end
+end
+```
+
+### Watcher Plugin Inteface
+Synapse deduces both the class path and class name from the `method` key within
+the watcher configuration.  Every watcher is passed configuration with the
+`method` key, e.g. `zookeeper` or `ec2tag`.
+
+#### Class Location
+Synapse expects to find your class at `synapse/service\_watcher/#{method}`. You
+must make your watcher available at that path, and Synapse can "just work" and
+find it.
+
+#### Class Name
+These method strings are then transformed into class names via the following
+function:
+
+```
+method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
+```
+
+This has the effect of taking the method, splitting on '_', capitalizing each
+part and recombining with an added 'Watcher' on the end. So `zookeeper\_dns`
+becomes `ZookeeperDnsWatcher`, and `zookeeper` becomes `Zookeeper`. Make sure
+your class name is correct.
+
+### Watcher Class Interface
+ServiceWatchers should conform to the interface provided by `BaseWatcher`:
+
+```
+start: start the watcher on a service registry
+
+stop: stop the watcher on a service registry
+
+ping?: healthcheck the watcher's connection to the service registry
+
+validate_discovery_opts: check if the configuration has the right options
+```
+
+When your watcher has received an update from the service registry you should
+call `set\_backends(new\_backends)` to trigger a sync of your watcher state
+with local HAProxy state.

--- a/lib/synapse/service_watcher/README.md
+++ b/lib/synapse/service_watcher/README.md
@@ -1,18 +1,33 @@
-Please, do not submit pull requests with new watchers, as Synapse and Nerve
-both support a plugin system for adding watchers and reporters respectively.
-
 ## Watcher Classes
 
 Watchers are the piece of Synapse that watch an external service registry
 and reflect those changes in the local HAProxy state. Watchers should look
 like:
 
-```
+```ruby
 require "synapse/service\_watcher/base"
 
 module Synapse::ServiceWatcher
   class MyWatcher < BaseWatcher
-  ...
+    def start
+      # write code which begins running service discovery
+    end
+
+    def stop
+      # write code which tears down the service discovery
+    end
+
+    def ping?
+      # write code to check in on the health of the watcher
+    end
+
+    private
+    def validate_discovery_opts
+      # here, validate any required options in @discovery
+    end
+
+    ...
+
   end
 end
 ```
@@ -50,6 +65,7 @@ stop: stop the watcher on a service registry
 
 ping?: healthcheck the watcher's connection to the service registry
 
+private
 validate_discovery_opts: check if the configuration has the right options
 ```
 

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -1,9 +1,9 @@
-require 'set'
 require 'synapse/log'
+require 'set'
 
-module Synapse
+class Synapse::ServiceWatcher
   class BaseWatcher
-    include Logging
+    include Synapse::Logging
 
     LEADER_WARN_INTERVAL = 30
 

--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -3,7 +3,7 @@ require "synapse/service_watcher/base"
 require 'thread'
 require 'resolv'
 
-module Synapse
+class Synapse::ServiceWatcher
   class DnsWatcher < BaseWatcher
     def start
       @check_interval = @discovery['check_interval'] || 30.0

--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -1,7 +1,7 @@
 require "synapse/service_watcher/base"
 require 'docker'
 
-module Synapse
+class Synapse::ServiceWatcher
   class DockerWatcher < BaseWatcher
     def start
       @check_interval = @discovery['check_interval'] || 15.0

--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -1,8 +1,8 @@
 require 'synapse/service_watcher/base'
 require 'aws-sdk'
 
-module Synapse
-  class EC2Watcher < BaseWatcher
+class Synapse::ServiceWatcher
+  class Ec2tagWatcher < BaseWatcher
 
     attr_reader :check_interval
 

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -3,7 +3,7 @@ require "synapse/service_watcher/base"
 require 'thread'
 require 'zk'
 
-module Synapse
+class Synapse::ServiceWatcher
   class ZookeeperWatcher < BaseWatcher
     NUMBERS_RE = /^\d+$/
 

--- a/lib/synapse/service_watcher/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns.rb
@@ -19,7 +19,7 @@ require 'thread'
 # for messages indicating that new servers are available, the check interval
 # has passed (triggering a re-resolve), or that the watcher should shut down.
 # The DNS watcher is responsible for the actual reconfiguring of backends.
-module Synapse
+class Synapse::ServiceWatcher
   class ZookeeperDnsWatcher < BaseWatcher
 
     # Valid messages that can be passed through the internal message queue
@@ -46,7 +46,7 @@ module Synapse
       CHECK_INTERVAL_MESSAGE = CheckInterval.new
     end
 
-    class Dns < Synapse::DnsWatcher
+    class Dns < Synapse::ServiceWatcher::DnsWatcher
 
       # Overrides the discovery_servers method on the parent class
       attr_accessor :discovery_servers
@@ -106,7 +106,7 @@ module Synapse
       end
     end
 
-    class Zookeeper < Synapse::ZookeeperWatcher
+    class Zookeeper < Synapse::ServiceWatcher::ZookeeperWatcher
       def initialize(opts={}, synapse, message_queue)
         super(opts, synapse)
 

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-class Synapse::BaseWatcher
+class Synapse::ServiceWatcher::BaseWatcher
   attr_reader :should_exit, :default_servers
 end
 
-describe Synapse::BaseWatcher do
+describe Synapse::ServiceWatcher::BaseWatcher do
   let(:mocksynapse) { double() }
-  subject { Synapse::BaseWatcher.new(args, mocksynapse) }
+  subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'base' }, 'haproxy' => {} }}
 
   def remove_arg(name)

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
+require 'synapse/service_watcher/docker'
 
-class Synapse::DockerWatcher
+class Synapse::ServiceWatcher::DockerWatcher
   attr_reader :check_interval, :watcher, :synapse
   attr_accessor :default_servers
 end
 
-describe Synapse::DockerWatcher do
+describe Synapse::ServiceWatcher::DockerWatcher do
   let(:mocksynapse) { double() }
-  subject { Synapse::DockerWatcher.new(testargs, mocksynapse) }
+  subject { Synapse::ServiceWatcher::DockerWatcher.new(testargs, mocksynapse) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'docker', 'servers' => [{'host' => 'server1.local', 'name' => 'mainserver'}], 'image_name' => 'mycool/image', 'container_port' => 6379 }, 'haproxy' => {} }}
   before(:each) do
     allow(subject.log).to receive(:warn)

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require 'synapse/service_watcher/ec2tag'
 require 'logging'
 
-class Synapse::EC2Watcher
+class Synapse::ServiceWatcher::Ec2tagWatcher
   attr_reader   :synapse
   attr_accessor :default_servers, :ec2
 end
@@ -28,9 +29,9 @@ class FakeAWSInstance
   end
 end
 
-describe Synapse::EC2Watcher do
+describe Synapse::ServiceWatcher::Ec2tagWatcher do
   let(:mock_synapse) { double }
-  subject { Synapse::EC2Watcher.new(basic_config, mock_synapse) }
+  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse) }
 
   let(:basic_config) do
     { 'name' => 'ec2tagtest',
@@ -88,22 +89,22 @@ describe Synapse::EC2Watcher do
     context 'when missing arguments' do
       it 'complains if aws_region is missing' do
         expect {
-          Synapse::EC2Watcher.new(remove_discovery_arg('aws_region'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse)
         }.to raise_error(ArgumentError, /Missing aws_region/)
       end
       it 'complains if aws_access_key_id is missing' do
         expect {
-          Synapse::EC2Watcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
         }.to raise_error(ArgumentError, /Missing aws_access_key_id/)
       end
       it 'complains if aws_secret_access_key is missing' do
         expect {
-          Synapse::EC2Watcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
         }.to raise_error(ArgumentError, /Missing aws_secret_access_key/)
       end
       it 'complains if server_port_override is missing' do
         expect {
-          Synapse::EC2Watcher.new(remove_haproxy_arg('server_port_override'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_haproxy_arg('server_port_override'), mock_synapse)
         }.to raise_error(ArgumentError, /Missing server_port_override/)
       end
     end
@@ -111,7 +112,7 @@ describe Synapse::EC2Watcher do
     context 'invalid data' do
       it 'complains if the haproxy server_port_override is not a number' do
           expect {
-            Synapse::EC2Watcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse)
+            Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse)
           }.to raise_error(ArgumentError, /Invalid server_port_override/)
       end
     end

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'synapse/service_watcher'
+
+describe Synapse::ServiceWatcher do
+  let(:mock_synapse) { double }
+  subject { Synapse::ServiceWatcher }
+  let(:config) do
+    {
+      'haproxy' => {
+        'port' => '8080',
+        'server_port_override' => '8081',
+      },
+      'discovery' => {
+        'method' => 'test'
+      }
+    }
+  end
+
+  def replace_discovery(new_value)
+    args = config.clone
+    args['discovery'] = new_value
+    args
+  end
+
+  context 'bogus arguments' do
+    it 'complains if discovery method is bogus' do
+      expect {
+        subject.create('test', config, mock_synapse)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'service watcher dispatch' do
+    let (:zookeeper_config) {{
+      'method' => 'zookeeper',
+      'hosts' => 'localhost:2181',
+      'path' => '/smartstack',
+    }}
+    let (:dns_config) {{
+      'method' => 'dns',
+      'servers' => ['localhost'],
+    }}
+    let (:docker_config) {{
+      'method' => 'docker',
+      'servers' => 'localhost',
+      'image_name' => 'servicefoo',
+      'container_port' => 1234,
+    }}
+    let (:ec2_config) {{
+      'method' => 'ec2tag',
+      'tag_name' => 'footag',
+      'tag_value' => 'barvalue',
+      'aws_access_key_id' => 'bogus',
+      'aws_secret_access_key' => 'morebogus',
+      'aws_region' => 'evenmorebogus',
+    }}
+    let (:zookeeper_dns_config) {{
+      'method' => 'zookeeper_dns',
+      'hosts' => 'localhost:2181',
+      'path' => '/smartstack',
+    }}
+
+    it 'creates zookeeper correctly' do
+      expect {
+        subject.create('test', replace_discovery(zookeeper_config), mock_synapse)
+      }.not_to raise_error
+    end
+    it 'creates dns correctly' do
+      expect {
+        subject.create('test', replace_discovery(dns_config), mock_synapse)
+      }.not_to raise_error
+    end
+    it 'creates docker correctly' do
+      expect {
+        subject.create('test', replace_discovery(docker_config), mock_synapse)
+      }.not_to raise_error
+    end
+    it 'creates ec2tag correctly' do
+      expect {
+        subject.create('test', replace_discovery(ec2_config), mock_synapse)
+      }.not_to raise_error
+    end
+    it 'creates zookeeper_dns correctly' do
+      expect {
+        subject.create('test', replace_discovery(zookeeper_dns_config), mock_synapse)
+      }.not_to raise_error
+    end
+  end
+
+end
+
+


### PR DESCRIPTION
Similar to what @bobtfish did in his nerve commit 258d62a823, this commit
allows Smartstack consumers to provide their own pluggable service
watchers.

Simply name your class correctly and put it in the right place and poof,
you have your own service watcher.