### PR TITLE
Support Netflix Exhibitor

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,3 @@ RSpec::Core::RakeTask.new(:spec)
 
 task :test => :spec
 task :default => :spec
-

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,6 +4,7 @@ require "synapse/service_watcher/ec2tag"
 require "synapse/service_watcher/dns"
 require "synapse/service_watcher/docker"
 require "synapse/service_watcher/zookeeper_dns"
+require "synapse/service_watcher/exhibitor"
 
 module Synapse
   class ServiceWatcher
@@ -15,6 +16,7 @@ module Synapse
       'dns' => DnsWatcher,
       'docker' => DockerWatcher,
       'zookeeper_dns' => ZookeeperDnsWatcher,
+      'exhibitor' => ExhibitorWatcher,
     }
 
     # the method which actually dispatches watcher creation requests

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,7 +4,7 @@ require "synapse/service_watcher/ec2tag"
 require "synapse/service_watcher/dns"
 require "synapse/service_watcher/docker"
 require "synapse/service_watcher/zookeeper_dns"
-require "synapse/service_watcher/exhibitor"
+require "synapse/service_watcher/zookeeper_exhibitor"
 
 module Synapse
   class ServiceWatcher
@@ -16,7 +16,7 @@ module Synapse
       'dns' => DnsWatcher,
       'docker' => DockerWatcher,
       'zookeeper_dns' => ZookeeperDnsWatcher,
-      'exhibitor' => ExhibitorWatcher,
+      'zookeeper_exhibitor' => ZookeeperExhibitorWatcher,
     }
 
     # the method which actually dispatches watcher creation requests

--- a/lib/synapse/service_watcher/exhibitor.rb
+++ b/lib/synapse/service_watcher/exhibitor.rb
@@ -1,0 +1,180 @@
+require "synapse/service_watcher/base"
+
+require 'zk'
+
+module Synapse
+  class ExhibitorWatcher < BaseWatcher
+    NUMBERS_RE = /^\d+$/
+
+    def start
+      @exhibitor_url = @discovery['exhibitor_url']
+      @zk_hosts = fetch_hosts_from_exhibitor
+
+      @watcher = nil
+      @zk = nil
+
+      log.info "synapse: starting ZK watcher #{@name} @ hosts: #{@zk_hosts}, path: #{@discovery['path']}"
+      zk_connect
+    end
+
+    def stop
+      log.warn "synapse: zookeeper watcher exiting"
+      zk_cleanup
+    end
+
+    def ping?
+      new_zk_hosts = fetch_hosts_from_exhibitor
+      if new_zk_hosts and @zk_hosts != new_zk_hosts
+        log.info "synapse: ZooKeeper ensamble changed, going to reconnect"
+        @zk_hosts = new_zk_hosts
+        stop
+        start
+      end
+      @zk && @zk.connected?
+    end
+
+    private
+
+    def validate_discovery_opts
+      raise ArgumentError, "invalid discovery method #{@discovery['method']}" \
+        unless @discovery['method'] == 'exhibitor'
+      raise ArgumentError, "missing or invalid exhibitor url for service #{@name}" \
+        unless @discovery['exhibitor_url']
+      raise ArgumentError, "invalid zookeeper path for service #{@name}" \
+        unless @discovery['path']
+    end
+
+    # helper method that ensures that the discovery path exists
+    def create(path)
+      log.debug "synapse: creating ZK path: #{path}"
+
+      # recurse if the parent node does not exist
+      create File.dirname(path) unless @zk.exists? File.dirname(path)
+      @zk.create(path, ignore: :node_exists)
+    end
+
+    # find the current backends at the discovery path; sets @backends
+    def discover
+      log.info "synapse: discovering backends for service #{@name}"
+
+      new_backends = []
+      @zk.children(@discovery['path'], :watch => true).each do |id|
+        node = @zk.get("#{@discovery['path']}/#{id}")
+
+        begin
+          host, port, name = deserialize_service_instance(node.first)
+        rescue StandardError => e
+          log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
+        else
+          server_port = @server_port_override ? @server_port_override : port
+
+          # find the numberic id in the node name; used for leader elections if enabled
+          numeric_id = id.split('_').last
+          numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
+
+          log.debug "synapse: discovered backend #{name} at #{host}:#{server_port} for service #{@name}"
+          new_backends << { 'name' => name, 'host' => host, 'port' => server_port, 'id' => numeric_id}
+        end
+      end
+
+      if new_backends.empty?
+        if @default_servers.empty?
+          log.warn "synapse: no backends and no default servers for service #{@name}; using previous backends: #{@backends.inspect}"
+        else
+          log.warn "synapse: no backends for service #{@name}; using default servers: #{@default_servers.inspect}"
+          @backends = @default_servers
+        end
+      else
+        log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
+        set_backends(new_backends)
+      end
+    end
+
+    def fetch_hosts_from_exhibitor
+      uri = URI(@exhibitor_url)
+      req = Net::HTTP::Get.new(uri)
+      if @discovery['exhibitor_user'] and @discovery['exhibitor_password']
+        req.basic_auth(@discovery['exhibitor_user'], @discovery['exhibitor_password'])
+      end
+      res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        http.request(req)
+      end
+
+      if res.code.to_i != 200
+        raise "Something went wrong: #{res.body}"
+      end
+      hosts = JSON.load(res.body)
+      log.info hosts
+      zk_hosts = hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
+      zk_hosts.sort.join(',')
+    end
+
+    # sets up zookeeper callbacks if the data at the discovery path changes
+    def watch
+      return if @zk.nil?
+
+      @watcher.unsubscribe unless @watcher.nil?
+      @watcher = @zk.register(@discovery['path'], &watcher_callback)
+
+      # Verify that we actually set up the watcher.
+      unless @zk.exists?(@discovery['path'], :watch => true)
+        log.error "synapse: zookeeper watcher path #{@discovery['path']} does not exist!"
+        raise RuntimeError.new('could not set a ZK watch on a node that should exist')
+      end
+    end
+
+    # handles the event that a watched path has changed in zookeeper
+    def watcher_callback
+      @callback ||= Proc.new do |event|
+        # Set new watcher
+        watch
+        # Rediscover
+        discover
+        # send a message to calling class to reconfigure
+        reconfigure!
+      end
+    end
+
+    def zk_cleanup
+      log.info "synapse: zookeeper watcher cleaning up"
+
+      @watcher.unsubscribe unless @watcher.nil?
+      @watcher = nil
+
+      @zk.close! unless @zk.nil?
+      @zk = nil
+
+      log.info "synapse: zookeeper watcher cleaned up successfully"
+    end
+
+    def zk_connect
+      log.info "synapse: zookeeper watcher connecting to ZK at #{@zk_hosts}"
+      @zk = ZK.new(@zk_hosts)
+
+      # handle session expiry -- by cleaning up zk, this will make `ping?`
+      # fail and so synapse will exit
+      @zk.on_expired_session do
+        log.warn "synapse: zookeeper watcher ZK session expired!"
+        zk_cleanup
+      end
+
+      # the path must exist, otherwise watch callbacks will not work
+      create(@discovery['path'])
+
+      # call the callback to bootstrap the process
+      watcher_callback.call
+    end
+
+    # decode the data at a zookeeper endpoint
+    def deserialize_service_instance(data)
+      log.debug "synapse: deserializing process data"
+      decoded = JSON.parse(data)
+
+      host = decoded['host'] || (raise ValueError, 'instance json data does not have host key')
+      port = decoded['port'] || (raise ValueError, 'instance json data does not have port key')
+      name = decoded['name'] || nil
+
+      return host, port, name
+    end
+  end
+end

--- a/lib/synapse/service_watcher/zookeeper_exhibitor.rb
+++ b/lib/synapse/service_watcher/zookeeper_exhibitor.rb
@@ -47,6 +47,7 @@ module Synapse
     end
 
     def poll
+      return unless @exhibitor_watcher.nil?
       @exhibitor_watcher = Thread.new do
         while true do
           new_zk_hosts = fetch_hosts_from_exhibitor
@@ -56,7 +57,6 @@ module Synapse
             stop
             @zk_hosts = new_zk_hosts
             start
-            break
           end
           sleep @discovery['exhibitor_poll_interval'] || DEFAULT_EXHIBITOR_POLL_INTERVAL
         end

--- a/lib/synapse/service_watcher/zookeeper_exhibitor.rb
+++ b/lib/synapse/service_watcher/zookeeper_exhibitor.rb
@@ -32,7 +32,7 @@ module Synapse
       # @zk being nil implies no session *or* a lost session, do not remove
       # the check on @zk being truthy
       return true if @change_in_progress
-      @zk && @zk.connected?
+      @exhibitor_watcher.alive? && @zk && @zk.connected?
     end
 
     private

--- a/lib/synapse/service_watcher/zookeeper_exhibitor.rb
+++ b/lib/synapse/service_watcher/zookeeper_exhibitor.rb
@@ -51,7 +51,7 @@ module Synapse
         while true do
           new_zk_hosts = fetch_hosts_from_exhibitor
           if new_zk_hosts && @zk_hosts != new_zk_hosts
-            log.info "synapse: ZooKeeper ensamble changed, stopping watcher"
+            log.info "synapse: ZooKeeper ensamble changed, going to reconnect"
             @change_in_progress = true
             stop
             @zk_hosts = new_zk_hosts

--- a/lib/synapse/service_watcher/zookeeper_exhibitor.rb
+++ b/lib/synapse/service_watcher/zookeeper_exhibitor.rb
@@ -1,11 +1,16 @@
 require "synapse/service_watcher/base"
 
+require 'thread'
 require 'zk'
 
 module Synapse
   class ZookeeperExhibitorWatcher < BaseWatcher
     NUMBERS_RE = /^\d+$/
-    DEFAULT_EXHIBITOR_POLL_INTERVAL = 5
+    DEFAULT_EXHIBITOR_POLL_INTERVAL = 10
+
+    @@zk_pool = {}
+    @@zk_pool_count = {}
+    @@zk_pool_lock = Mutex.new
 
     def start
       @zk_hosts = fetch_hosts_from_exhibitor
@@ -15,7 +20,7 @@ module Synapse
 
       log.info "synapse: starting ZK watcher #{@name} @ hosts: #{@zk_hosts}, path: #{@discovery['path']}"
       zk_connect
-      poll
+      @change_in_progress = false
     end
 
     def stop
@@ -24,24 +29,13 @@ module Synapse
     end
 
     def ping?
+      # @zk being nil implies no session *or* a lost session, do not remove
+      # the check on @zk being truthy
+      return true if @change_in_progress
       @zk && @zk.connected?
     end
 
     private
-
-    def poll
-      @exhibitor_watcher = Thread.new do
-        while true do
-          new_zk_hosts = fetch_hosts_from_exhibitor
-          if new_zk_hosts and @zk_hosts != new_zk_hosts
-            log.info "synapse: ZooKeeper ensamble changed, stopping watcher"
-            stop
-            break
-          end
-          sleep @discovery['exhibitor_poll_interval'] || DEFAULT_EXHIBITOR_POLL_INTERVAL
-        end
-      end
-    end
 
     def validate_discovery_opts
       raise ArgumentError, "invalid discovery method #{@discovery['method']}" \
@@ -50,6 +44,44 @@ module Synapse
         unless @discovery['exhibitor_url']
       raise ArgumentError, "invalid zookeeper path for service #{@name}" \
         unless @discovery['path']
+    end
+
+    def poll
+      @exhibitor_watcher = Thread.new do
+        while true do
+          new_zk_hosts = fetch_hosts_from_exhibitor
+          if new_zk_hosts && @zk_hosts != new_zk_hosts
+            log.info "synapse: ZooKeeper ensamble changed, stopping watcher"
+            @change_in_progress = true
+            stop
+            @zk_hosts = new_zk_hosts
+            start
+            break
+          end
+          sleep @discovery['exhibitor_poll_interval'] || DEFAULT_EXHIBITOR_POLL_INTERVAL
+        end
+      end
+    end
+
+    def fetch_hosts_from_exhibitor
+      uri = URI(@discovery['exhibitor_url'])
+      req = Net::HTTP::Get.new(uri.request_uri)
+      if @discovery['exhibitor_user'] && @discovery['exhibitor_password']
+        req.basic_auth(@discovery['exhibitor_user'], @discovery['exhibitor_password'])
+      end
+      req.add_field('Accept', 'application/json')
+      res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+        http.request(req)
+      end
+
+      if res.code.to_i != 200
+        log.error "Something went wrong: #{res.body}"
+        return
+      end
+      hosts = JSON.load(res.body)
+      log.debug hosts
+      zk_hosts = hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
+      zk_hosts.sort.join(',')
     end
 
     # helper method that ensures that the discovery path exists
@@ -61,7 +93,7 @@ module Synapse
       @zk.create(path, ignore: :node_exists)
     end
 
-    # find the current backends at the discovery path; sets @backends
+    # find the current backends at the discovery path
     def discover
       log.info "synapse: discovering backends for service #{@name}"
 
@@ -70,7 +102,7 @@ module Synapse
         node = @zk.get("#{@discovery['path']}/#{id}")
 
         begin
-          host, port, name = deserialize_service_instance(node.first)
+          host, port, name, weight = deserialize_service_instance(node.first)
         rescue StandardError => e
           log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
         else
@@ -81,46 +113,17 @@ module Synapse
           numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
 
           log.debug "synapse: discovered backend #{name} at #{host}:#{server_port} for service #{@name}"
-          new_backends << { 'name' => name, 'host' => host, 'port' => server_port, 'id' => numeric_id}
+          new_backends << { 'name' => name, 'host' => host, 'port' => server_port, 'id' => numeric_id, 'weight' => weight }
         end
       end
 
-      if new_backends.empty?
-        if @default_servers.empty?
-          log.warn "synapse: no backends and no default servers for service #{@name}; using previous backends: #{@backends.inspect}"
-        else
-          log.warn "synapse: no backends for service #{@name}; using default servers: #{@default_servers.inspect}"
-          @backends = @default_servers
-        end
-      else
-        log.info "synapse: discovered #{new_backends.length} backends for service #{@name}"
-        set_backends(new_backends)
-      end
-    end
-
-    def fetch_hosts_from_exhibitor
-      uri = URI(@discovery['exhibitor_url'])
-      req = Net::HTTP::Get.new(uri)
-      if @discovery['exhibitor_user'] and @discovery['exhibitor_password']
-        req.basic_auth(@discovery['exhibitor_user'], @discovery['exhibitor_password'])
-      end
-      req.add_field('Accept', 'application/json')
-      res = Net::HTTP.start(uri.hostname, uri.port) do |http|
-        http.request(req)
-      end
-
-      if res.code.to_i != 200
-        raise "Something went wrong: #{res.body}"
-      end
-      hosts = JSON.load(res.body)
-      log.debug hosts
-      zk_hosts = hosts['servers'].map { |s| s.concat(':' + hosts['port'].to_s) }
-      zk_hosts.sort.join(',')
+      set_backends(new_backends)
     end
 
     # sets up zookeeper callbacks if the data at the discovery path changes
     def watch
       return if @zk.nil?
+      log.debug "synapse: setting watch at #{@discovery['path']}"
 
       @watcher.unsubscribe unless @watcher.nil?
       @watcher = @zk.register(@discovery['path'], &watcher_callback)
@@ -130,6 +133,7 @@ module Synapse
         log.error "synapse: zookeeper watcher path #{@discovery['path']} does not exist!"
         raise RuntimeError.new('could not set a ZK watch on a node that should exist')
       end
+      log.debug "synapse: set watch at #{@discovery['path']}"
     end
 
     # handles the event that a watched path has changed in zookeeper
@@ -139,26 +143,56 @@ module Synapse
         watch
         # Rediscover
         discover
-        # send a message to calling class to reconfigure
-        reconfigure!
       end
     end
 
     def zk_cleanup
       log.info "synapse: zookeeper watcher cleaning up"
 
-      @watcher.unsubscribe unless @watcher.nil?
-      @watcher = nil
-
-      @zk.close! unless @zk.nil?
-      @zk = nil
+      begin
+        @watcher.unsubscribe unless @watcher.nil?
+        @watcher = nil
+      ensure
+        @@zk_pool_lock.synchronize {
+          if @@zk_pool.has_key?(@zk_hosts)
+            @@zk_pool_count[@zk_hosts] -= 1
+            # Last thread to use the connection closes it
+            if @@zk_pool_count[@zk_hosts] == 0
+              log.info "synapse: closing zk connection to #{@zk_hosts}"
+              begin
+                @zk.close! unless @zk.nil?
+              ensure
+                @@zk_pool.delete(@zk_hosts)
+              end
+            end
+          end
+          @zk = nil
+        }
+      end
 
       log.info "synapse: zookeeper watcher cleaned up successfully"
     end
 
     def zk_connect
       log.info "synapse: zookeeper watcher connecting to ZK at #{@zk_hosts}"
-      @zk = ZK.new(@zk_hosts)
+
+      # Ensure that all Zookeeper watcher re-use a single zookeeper
+      # connection to any given set of zk hosts.
+      @@zk_pool_lock.synchronize {
+        unless @@zk_pool.has_key?(@zk_hosts)
+          log.info "synapse: creating pooled connection to #{@zk_hosts}"
+          @@zk_pool[@zk_hosts] = ZK.new(@zk_hosts, :timeout => 5, :thread => :per_callback)
+          @@zk_pool_count[@zk_hosts] = 1
+          poll
+          log.info "synapse: successfully created zk connection to #{@zk_hosts}"
+        else
+          @@zk_pool_count[@zk_hosts] += 1
+          log.info "synapse: re-using existing zookeeper connection to #{@zk_hosts}"
+        end
+      }
+
+      @zk = @@zk_pool[@zk_hosts]
+      log.info "synapse: retrieved zk connection to #{@zk_hosts}"
 
       # handle session expiry -- by cleaning up zk, this will make `ping?`
       # fail and so synapse will exit
@@ -182,8 +216,9 @@ module Synapse
       host = decoded['host'] || (raise ValueError, 'instance json data does not have host key')
       port = decoded['port'] || (raise ValueError, 'instance json data does not have port key')
       name = decoded['name'] || nil
+      weight = decoded['weight'] || nil
 
-      return host, port, name
+      return host, port, name, weight
     end
   end
 end


### PR DESCRIPTION
This PR will add support for Netflix Exhibitor. It's more or less a copy of the regular zookeeper watcher adding but adds polling of the Exhibitor REST endpoint for zk ensemble changes. If the ensemble changes this watcher will detect that and stop the watcher.

This is great when maintaining zookeeper in the cloud to not have static zookeeper endpoints. 
