### PR TITLE
Explicit watcher haproxy backend names

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ This section is its own hash, which should contain the following keys:
 * `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out.
 * `frontend`: additional lines passed to the HAProxy config in the `frontend` stanza of this service
 * `backend`: additional lines passed to the HAProxy config in the `backend` stanza of this service
+* `backend_name`: The name of the generated HAProxy backend for this service
+  (defaults to the service's key in the `services` section)
 * `listen`: these lines will be parsed and placed in the correct `frontend`/`backend` section as applicable; you can put lines which are the same for the frontend and backend here.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
 

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -688,7 +688,7 @@ module Synapse
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
         "\tbind #{@opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
-        "\tdefault_backend #{watcher.name}"
+        "\tdefault_backend #{watcher.haproxy.fetch('backend_name', watcher.name)}"
       ]
     end
 
@@ -713,7 +713,7 @@ module Synapse
       end
 
       stanza = [
-        "\nbackend #{watcher.name}",
+        "\nbackend #{watcher.haproxy.fetch('backend_name', watcher.name)}",
         config.map {|c| "\t#{c}"},
         backends.keys.shuffle.map {|backend_name|
           backend = backends[backend_name]


### PR DESCRIPTION
This allows acls in frontend sections to reference backends without coupling
to the current convention of naming backends after watcher names

We're interested in doing farm failover at Yelp as described in http://blog.haproxy.com/2013/12/23/failover-and-worst-case-management-with-haproxy/ and I think all we need to do this is to have backup service watchers that have no port (so they'll get no frontend) and then have acls in the main service watchers that redirect to the backup backends if needed. However, to do this we need to know the names of backends and I'd rather not couple our configuration to something that synapse reserves the right to change.