### PR TITLE
Do not unregister the callback in the zk watcher

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -89,7 +89,7 @@ module Synapse
       # Verify that we actually set up the watcher.
       unless @zk.exists?(@discovery['path'], :watch => true)
         log.error "synapse: zookeeper watcher path #{@discovery['path']} does not exist!"
-        raise RuntimeError.new('could not set a ZK watch on a node that should exist')
+        zk_cleanup
       end
       log.debug "synapse: set watch at #{@discovery['path']}"
     end

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -84,8 +84,7 @@ module Synapse
       return if @zk.nil?
       log.debug "synapse: setting watch at #{@discovery['path']}"
 
-      @watcher.unsubscribe unless @watcher.nil?
-      @watcher = @zk.register(@discovery['path'], &watcher_callback)
+      @watcher = @zk.register(@discovery['path'], &watcher_callback) unless @watcher
 
       # Verify that we actually set up the watcher.
       unless @zk.exists?(@discovery['path'], :watch => true)


### PR DESCRIPTION
Addresses incompatibility of per_callback threading in ZK, the way that
synapse calls unsubscribe within the callback, and ruby 2.X really not
liking joining on the current running thread.

Should fix #137 #99 and possibly #94 

I've tested this manually and events seem to get propagated ... I'd like to roll this out to a small portion of our infrastructure and see how it behaves.