### PR TITLE
Update README.md with better installation directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,19 +92,26 @@ HAProxy will be transparently reloaded, and your application will keep running w
 
 ## Installation
 
-Add this line to your application's Gemfile:
+To download and run the synapse binary, first install a version of ruby.
 
-    gem 'synapse'
+```bash
+$ mkdir -p /opt/smartstack/synapse
+$ gem install synapse --install-dir /opt/smartstack/synapse --no-document
+```
 
-And then execute:
+This will download synapse and its dependencies into /opt/smartstack/synapse. You
+might wish to omit the `--install-dir` flag to use your system's default gem
+path, however this will require you to run `gem install synapse` with root
+permissions.
 
-    $ bundle
+You can now run the synapse binary like:
 
-Or install it yourself as:
+```bash
+export GEM_PATH=/opt/smartstack/synapse
+/opt/smartstack/synapse/bin/synapse --help
+```
 
-    $ gem install synapse
-
-Don't forget to install HAProxy prior to installing Synapse.
+Don't forget to install HAProxy too.
 
 ## Configuration ##
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ HAProxy will be transparently reloaded, and your application will keep running w
 
 ## Installation
 
-To download and run the synapse binary, first install a version of ruby.
+To download and run the synapse binary, first install a version of ruby. Then,
+install synapse with:
 
 ```bash
 $ mkdir -p /opt/smartstack/synapse


### PR DESCRIPTION
The previous installation directions are not great -- they are ambiguous
between whether synapse should be used as a library (and placed in the
depending app's Gemfile) vs being used as a standalone application (and
installed via `gem install`).

The best way I know to deploy a Ruby application is to use `gem install
--install-dir [path]` to install the application in that path. This
allows:

* the gem to be installed by any user, not just root
* the version of synapse's dependencies to be isolated from other system
  gems
* easier redistribution as a system package

The downside is a relative large disk footprint - 36 MB as of writing.
Many files could be excluded from a system package, like the cache/
directory.