### PR TITLE
Cleanup old files that synapse no longer manages

### DIFF
--- a/spec/lib/synapse/file_output_spec.rb
+++ b/spec/lib/synapse/file_output_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'fileutils'
+
+describe Synapse::FileOutput do
+  subject { Synapse::FileOutput.new(config['file_output']) }
+
+  before(:example) do
+    FileUtils.mkdir_p(config['file_output']['output_directory'])
+  end
+
+  after(:example) do
+    FileUtils.rm_r(config['file_output']['output_directory'])
+  end
+
+  let(:mockwatcher_1) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    backends = [{ 'host' => 'somehost', 'port' => 5555}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    mockWatcher
+  end
+  let(:mockwatcher_2) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('foobar_service')
+    backends = [{ 'host' => 'somehost', 'port' => 1234}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    mockWatcher
+  end
+
+  it 'updates the config' do
+    expect(subject).to receive(:write_backends_to_file)
+    subject.update_config([mockwatcher_1])
+  end
+
+  it 'manages correct files' do
+    subject.update_config([mockwatcher_1, mockwatcher_2])
+    FileUtils.cd(config['file_output']['output_directory']) do
+      expect(Dir.glob('*.json')).to eql(['example_service.json', 'foobar_service.json'])
+    end
+    # Should clean up after itself
+    subject.update_config([mockwatcher_1])
+    FileUtils.cd(config['file_output']['output_directory']) do
+      expect(Dir.glob('*.json')).to eql(['example_service.json'])
+    end
+    # Should clean up after itself
+    subject.update_config([])
+    FileUtils.cd(config['file_output']['output_directory']) do
+      expect(Dir.glob('*.json')).to eql([])
+    end
+  end
+
+  it 'writes correct content' do
+    subject.update_config([mockwatcher_1])
+    data_path = File.join(config['file_output']['output_directory'],
+                          "example_service.json")
+    old_backends = JSON.load(File.read(data_path))
+    expect(old_backends.length).to eql(1)
+    expect(old_backends.first['host']).to eql('somehost')
+    expect(old_backends.first['port']).to eql(5555)
+  end
+end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -8,7 +8,7 @@ describe Synapse::Haproxy do
   let(:mockwatcher) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service')
-    backends = [{ 'host' => 'somehost', 'port' => '5555'}]
+    backends = [{ 'host' => 'somehost', 'port' => 5555}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
     allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2"})
     mockWatcher
@@ -17,7 +17,7 @@ describe Synapse::Haproxy do
   let(:mockwatcher_with_server_options) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service')
-    backends = [{ 'host' => 'somehost', 'port' => '5555', 'haproxy_server_options' => 'backup'}]
+    backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_options' => 'backup'}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
     allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2"})
     mockWatcher

--- a/spec/support/minimum.conf.yaml
+++ b/spec/support/minimum.conf.yaml
@@ -22,6 +22,11 @@ haproxy:
   do_reloads: false
   global:
     - global_test_option
-    
+
   defaults:
     - default_test_option
+
+
+# settings for the file output generator
+file_output:
+  output_directory: "/tmp/synapse_file_output_test"


### PR DESCRIPTION
It turns out that when removing services these files stick around
because synapse stops managing them, so in this patch we clean up
anything in the output directory that shouldn't be there.

Should fix #139

Also adds tests of the file output generator.
