### PR TITLE
add apache aurora service discovery support - issues/147

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -41,6 +41,7 @@ class Synapse::ServiceWatcher
         unless @discovery['hosts']
       raise ArgumentError, "invalid zookeeper path for service #{@name}" \
         unless @discovery['path']
+      @decode_method = JSON.parse
       if @discovery['decode']
         raise ArgumentError, "missing or invalid decode method #{@discovery['decode']}" \
           unless @discovery['decode']['method']
@@ -52,8 +53,6 @@ class Synapse::ServiceWatcher
               JSON.parse(data)['serviceEndpoint']
             end
           end
-        else
-          @decode_method = JSON.parse
         end
       end
     end

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -175,6 +175,10 @@ class Synapse::ServiceWatcher
       log.debug "synapse: deserializing process data"
       decoded = JSON.parse(data)
 
+      # supporting Apache Aurora style service discovery
+      if decoded.include? 'serviceEndpoint' and decoded.include? 'status' and decoded['status'] == 'ALIVE'
+        decoded = decoded['serviceEndpoint']
+      end
       host = decoded['host'] || (raise ValueError, 'instance json data does not have host key')
       port = decoded['port'] || (raise ValueError, 'instance json data does not have port key')
       name = decoded['name'] || nil


### PR DESCRIPTION
Adding support for aurora style service discovery.

Without patch:
```shell
[root@c90f0a9b92d9 /]# /usr/local/bin/synapse -c /etc/synapse/synapse.json
W, [2015-11-25T16:54:33.707037 #56]  WARN -- Synapse::ZookeeperWatcher: synapse: service hello_world: haproxy config does not include a port; only backend sections for the service will be created; you must move traffic there manually using configuration in `extra_sections`
I, [2015-11-25T16:54:33.707253 #56]  INFO -- Synapse::Synapse: synapse: starting...
I, [2015-11-25T16:54:33.707291 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: starting ZK watcher hello_world @ hosts: 10.150.150.224:2181, path: /aurora/nobody/devel/hello_world
I, [2015-11-25T16:54:33.707315 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 10.150.150.224:2181
I, [2015-11-25T16:54:33.707337 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: creating pooled connection to 10.150.150.224:2181
I, [2015-11-25T16:54:33.829500 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: successfully created zk connection to 10.150.150.224:2181
I, [2015-11-25T16:54:33.829642 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: retrieved zk connection to 10.150.150.224:2181
I, [2015-11-25T16:54:34.051414 #56]  INFO -- Synapse::ZookeeperWatcher: synapse: discovering backends for service hello_world
E, [2015-11-25T16:54:34.219371 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000028 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.291087 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000036 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.363133 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000027 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.434785 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000031 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.526296 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000030 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.598868 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000035 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.675987 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000034 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.752758 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000033 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
E, [2015-11-25T16:54:34.827884 #56] ERROR -- Synapse::ZookeeperWatcher: synapse: invalid data in ZK node member_0000000032 at /aurora/nobody/devel/hello_world: uninitialized constant Synapse::ZookeeperWatcher::ValueError
```

With patch:
```shell
[root@c90f0a9b92d9 /]# /usr/local/bin/synapse -c /etc/synapse/synapse.json
W, [2015-11-25T16:42:28.500523 #44]  WARN -- Synapse::ZookeeperWatcher: synapse: service hello_world: haproxy config does not include a port; only backend sections for the service will be created; you must move traffic there manually using configuration in `extra_sections`
I, [2015-11-25T16:42:28.500835 #44]  INFO -- Synapse::Synapse: synapse: starting...
I, [2015-11-25T16:42:28.500954 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: starting ZK watcher hello_world @ hosts: 10.150.150.224:2181, path: /aurora/nobody/devel/hello_world
I, [2015-11-25T16:42:28.501033 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 10.150.150.224:2181
I, [2015-11-25T16:42:28.501109 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: creating pooled connection to 10.150.150.224:2181
I, [2015-11-25T16:42:28.587700 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: successfully created zk connection to 10.150.150.224:2181
I, [2015-11-25T16:42:28.587919 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: retrieved zk connection to 10.150.150.224:2181
I, [2015-11-25T16:42:28.827093 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: discovering backends for service hello_world
I, [2015-11-25T16:42:29.833430 #44]  INFO -- Synapse::ZookeeperWatcher: synapse: discovered 9 backends for service hello_world
I, [2015-11-25T16:42:29.833840 #44]  INFO -- Synapse::Synapse: synapse: configuring haproxy
```