### PR TITLE
allow bind_address in the service haproxy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ by unsetting `use_previous_backends`.
 This section is its own hash, which should contain the following keys:
 
 * `port`: the port (on localhost) where HAProxy will listen for connections to the service. If this is omitted, only a backend stanza (and no frontend stanza) will be generated for this service; you'll need to get traffic to your service yourself via the `shared_frontend` or manual frontends in `extra_sections`
+* `bind_address`: force HAProxy to listen on this address ( default is localhost ). Setting `bind_address` on a per service basis overrides the global `bind_address` in the top level `haproxy`. Having HAProxy listen for connections on different addresses ( example: service1 listen on 127.0.0.2:443 and service2 listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
 * `server_port_override`: the port that discovered servers listen on; you should specify this if your discovery mechanism only discovers names or addresses (like the DNS watcher). If the discovery method discovers a port along with hostnames (like the zookeeper watcher) this option may be left out, but will be used in preference if given.
 * `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out.
 * `frontend`: additional lines passed to the HAProxy config in the `frontend` stanza of this service

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -686,7 +686,7 @@ module Synapse
       stanza = [
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-        "\tbind #{@opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
+        "\tbind #{ watcher.haproxy['bind_address'] || @opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
         "\tdefault_backend #{watcher.haproxy.fetch('backend_name', watcher.name)}"
       ]
     end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -23,6 +23,21 @@ describe Synapse::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_frontend) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:haproxy).and_return('port' => 2200)
+    mockWatcher
+  end
+
+  let(:mockwatcher_frontend_with_bind_address) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:haproxy).and_return('port' => 2200, 'bind_address' => "127.0.0.3")
+    mockWatcher
+  end
+
+
   it 'updating the config' do
     expect(subject).to receive(:generate_config)
     subject.update_config([mockwatcher])
@@ -42,4 +57,15 @@ describe Synapse::Haproxy do
     mockConfig = []
     expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
   end
+
+  it 'generates frontend stanza ' do
+    mockConfig = []
+    expect(subject.generate_frontend_stanza(mockwatcher_frontend, mockConfig)).to eql(["\nfrontend example_service", [], "\tbind localhost:2200", "\tdefault_backend example_service"])
+  end
+
+  it 'respects frontend bind_address ' do
+    mockConfig = []
+    expect(subject.generate_frontend_stanza(mockwatcher_frontend_with_bind_address, mockConfig)).to eql(["\nfrontend example_service", [], "\tbind 127.0.0.3:2200", "\tdefault_backend example_service"])
+  end
+
 end


### PR DESCRIPTION
Update lib/synapse/haproxy.rb to allow bind_address in the service haproxy section.   Allows bind address to be set per service and to override the global bind_address when needed.

My current use case is to configure services on local IPs ( myapi_brancha 127.0.0.2:443, myapi_anotherbranch 127.0.0.3:443 ) and then setup /etc/host entries to point to the services.   

```
# synapse.conf.json
...
  "services": {
    "myapi_brancha": {
     ...
      "haproxy": {
        "port": 443,
        "bind_address": "127.0.0.2",
    "myapi_anotherbranch": {
     ...
      "haproxy": {
        "port": 443,
        "bind_address": "127.0.0.3",
```
```
# /etc/hosts 
127.0.0.2 myapi_brancha
127.0.0.3 myapi_anotherbranch
```
 
This allows front end applications using smartstack to access an api by name rather than port.   Will use this in a dev environment where there are multiple application servers each on a different branch and developers need to easily change which branch they are using.