### PR TITLE
Fix service discovery under Aurora

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -240,8 +240,8 @@ class Synapse::ServiceWatcher
       log.debug "synapse: deserializing process data"
       decoded = @decode_method.call(data)
 
-      host = decoded['host'] || (raise KeyError, 'instance json data does not have host key')
-      port = decoded['port'] || (raise KeyError, 'instance json data does not have port key')
+      host = decoded['serviceEndpoint']['host'] || (raise KeyError, 'instance json data does not have host key')
+      port = decoded['serviceEndpoint']['port'] || (raise KeyError, 'instance json data does not have port key')
       name = decoded['name'] || nil
       weight = decoded['weight'] || nil
       haproxy_server_options = decoded['haproxy_server_options'] || nil


### PR DESCRIPTION
It logs "ERROR -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse:
invalid data in ZK node member_0000000004 at
/aurora/aa/ubuntu/devel/rising: uninitialized constant
Synapse::ServiceWatcher::ZookeeperWatcher::ValueError"

It does this because the host and port are inside another level of JSON
hash in an Aurora ServerSet record; they're not out at toplevel.