### PR TITLE
Service watcher supports filtering backends by label 

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -127,7 +127,7 @@ class Synapse::ServiceWatcher
 
         begin
           # TODO: Do less munging, or refactor out this processing
-          host, port, name, weight, haproxy_server_options = deserialize_service_instance(node.first)
+          host, port, name, weight, haproxy_server_options, labels = deserialize_service_instance(node.first)
         rescue StandardError => e
           log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
         else
@@ -141,7 +141,8 @@ class Synapse::ServiceWatcher
           new_backends << {
             'name' => name, 'host' => host, 'port' => server_port,
             'id' => numeric_id, 'weight' => weight,
-            'haproxy_server_options' => haproxy_server_options
+            'haproxy_server_options' => haproxy_server_options,
+            'labels' => labels
           }
         end
       end
@@ -245,8 +246,9 @@ class Synapse::ServiceWatcher
       name = decoded['name'] || nil
       weight = decoded['weight'] || nil
       haproxy_server_options = decoded['haproxy_server_options'] || nil
+      labels = decoded['labels'] || nil
 
-      return host, port, name, weight, haproxy_server_options
+      return host, port, name, weight, haproxy_server_options, labels
     end
   end
 end


### PR DESCRIPTION
## Synapse filters service instances by labels into multiple backends

### Overview

The high level context for this commit: we want to allow users to configure Synapse to distinguish different pools of service instances and to route traffic between them based on user configuration.

Original Discussion PR: https://github.com/airbnb/nerve/pull/81

### Details

Synapse's `discovery` configuration will support a new section `label_filter`. Let's assume the user is interested in setting up failover from the local availability zone to other nodes in the same region and eventually failing over to any available global instance.


```json
{ 
  "example_service":  {
    "haproxy": {
      "backend_name": "example_service_default",
      "frontend": [
        "acl use_local_backend nbsrv(example_service_local) gt 2",
        "acl use_regional_backend nbsrv(example_service_regional) gt 2",
        "use_backend example_service_local use_local_backend",
        "use_backend example_service_regional use_regional_backend",
      ],
    },
  }
}
```

This configuration comes with additional service definitions with different `label_filter` options:

```json
{
  "example_service_local": {
    "discovery": {
      "label_filter": { "label": "az", "value": "us-east-1a", "condition": "equals" },
    }
},
  "example_service_regional": {
    "discovery": {
      "label_filter": { "label": "region", "value": "us-east-1", "condition": "equals" },
    }
  }
}
```

Given a set of service instances for `my-service` reporting the following service data:
```json
{
  "somehost:1111": { "host": "somehost", "port": 1111, "labels": { "az": "us-east-1a", "region": "us-east-1" } },
  "somehost:2222": { "host": "somehost", "port": 2222, "labels": { "az": "us-east-1a", "region": "us-east-1" } },
  "somehost:3333": { "host": "somehost", "port": 3333, "labels": { "az": "us-east-1c", "region": "us-east-1" } },
  "somehost:4444": { "host": "somehost", "port": 4444, "labels": { "az": "us-west-2a", "region": "us-west-2" } },
  "somehost:5555": { "host": "somehost", "port": 5555, "labels": { "az": "eu-central-1a", "region": "eu-central" } }
}
```

Synapse is expected to produce the following HAProxy configuration:
```
frontend example_service
  acl use_local_backend nbsrv(example_service_local) gt 2
  acl use_regional_backend nbsrv(example_service_regional) gt 2
  use_backend example_service_local use_local_backend
  use_backend example_service_regional use_regional_backend
  default_backend example_service_default

backend example_service_default
  server somehost:1111 somehost:1111 cookie somehost:1111
  server somehost:2222 somehost:2222 cookie somehost:2222
  server somehost:3333 somehost:3333 cookie somehost:3333
  server somehost:4444 somehost:4444 cookie somehost:4444
  server somehost:5555 somehost:5555 cookie somehost:5555

backend example_service_local
  server somehost:1111 somehost:1111 cookie somehost:1111
  server somehost:2222 somehost:2222 cookie somehost:2222

backend example_service_regional
  server somehost:1111 somehost:1111 cookie somehost:1111
  server somehost:2222 somehost:2222 cookie somehost:2222
  server somehost:3333 somehost:3333 cookie somehost:3333

```