### PR TITLE
Permit to hash server identifier for backend affinity stored in cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ This section is its own hash, which should contain the following keys:
   (defaults to the service's key in the `services` section)
 * `listen`: these lines will be parsed and placed in the correct `frontend`/`backend` section as applicable; you can put lines which are the same for the frontend and backend here.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
+* `cookie_hash_servernames`: optional: if true, synapse hashes backend names on cookie value assignation of your discovered backends, useful in http mode and when you want to use haproxy cookie feature but you do not want that your end users receive a Set-Cookie with your server name and ip readable in clear
 
 <a name="haproxy"/>
 ### Configuring HAProxy ###

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -23,6 +23,15 @@ describe Synapse::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_with_cookie_hash_servernames) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    backends = [{ 'host' => 'somehost', 'port' => 5555}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2", 'cookie_hash_servernames' => true})
+    mockWatcher
+  end
+
   let(:mockwatcher_frontend) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service')
@@ -46,6 +55,11 @@ describe Synapse::Haproxy do
   it 'generates backend stanza' do
     mockConfig = []
     expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
+  end
+
+  it 'hashes backend cookie value' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_hash_servernames, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'generates backend stanza without cookies for tcp mode' do


### PR DESCRIPTION
Avoid to send server + port in clear to endusers