### PR TITLE
Add `backend_order` option support to `haproxy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ This section is its own hash, which should contain the following keys:
 * `backend_name`: The name of the generated HAProxy backend for this service
   (defaults to the service's key in the `services` section)
 * `listen`: these lines will be parsed and placed in the correct `frontend`/`backend` section as applicable; you can put lines which are the same for the frontend and backend here.
+* `backend_order`: optional: how backends should be ordered in the `backend` stanza. (default is shuffling). Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza. `desc` means descending alphabetical order. `no_shuffle` means no shuffling or sorting.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
 
 <a name="haproxy"/>

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -721,10 +721,20 @@ module Synapse
         log.debug "synapse: no backends found for watcher #{watcher.name}"
       end
 
+      keys = case watcher.haproxy['backend_order']
+      when 'asc'
+        backends.keys.sort
+      when 'desc'
+        backends.keys.sort.reverse
+      when 'no_shuffle'
+        backends.keys
+      else
+        backends.keys.shuffle
+      end
       stanza = [
         "\nbackend #{watcher.haproxy.fetch('backend_name', watcher.name)}",
         config.map {|c| "\t#{c}"},
-        backends.keys.shuffle.map {|backend_name|
+        keys.map {|backend_name|
           backend = backends[backend_name]
           b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}"
           b = "#{b} cookie #{backend_name}" unless config.include?('mode tcp')

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -48,6 +48,34 @@ describe Synapse::Haproxy do
     expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
   end
 
+  describe 'generate backend stanza in correct order' do
+    let(:multiple_backends_stanza_map) do
+      {
+        'asc' => ["\nbackend example_service", [], ["\tserver somehost1:5555 somehost1:5555 cookie somehost1:5555 check inter 2000 rise 3 fall 2", "\tserver somehost2:5555 somehost2:5555 cookie somehost2:5555 check inter 2000 rise 3 fall 2", "\tserver somehost3:5555 somehost3:5555 cookie somehost3:5555 check inter 2000 rise 3 fall 2"]],
+        'desc' => ["\nbackend example_service", [], ["\tserver somehost3:5555 somehost3:5555 cookie somehost3:5555 check inter 2000 rise 3 fall 2", "\tserver somehost2:5555 somehost2:5555 cookie somehost2:5555 check inter 2000 rise 3 fall 2", "\tserver somehost1:5555 somehost1:5555 cookie somehost1:5555 check inter 2000 rise 3 fall 2"]],
+        'no_shuffle' => ["\nbackend example_service", [], ["\tserver somehost1:5555 somehost1:5555 cookie somehost1:5555 check inter 2000 rise 3 fall 2", "\tserver somehost3:5555 somehost3:5555 cookie somehost3:5555 check inter 2000 rise 3 fall 2", "\tserver somehost2:5555 somehost2:5555 cookie somehost2:5555 check inter 2000 rise 3 fall 2"]]
+      }
+    end
+
+    let(:mockwatcher_with_multiple_backends) do
+      mockWatcher = double(Synapse::ServiceWatcher)
+      allow(mockWatcher).to receive(:name).and_return('example_service')
+      backends = [{ 'host' => 'somehost1', 'port' => 5555}, {'host' => 'somehost3', 'port' => 5555}, { 'host' => 'somehost2', 'port' => 5555}]
+      allow(mockWatcher).to receive(:backends).and_return(backends)
+      mockWatcher
+    end
+
+    ['asc', 'desc', 'no_shuffle'].each do |order_option|
+      context "when #{order_option} is specified for backend_order" do
+        it 'generates backend stanza in correct order' do
+          mockConfig = []
+          allow(mockwatcher_with_multiple_backends).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2", 'backend_order' => order_option})
+          expect(subject.generate_backend_stanza(mockwatcher_with_multiple_backends, mockConfig)).to eql(multiple_backends_stanza_map[order_option])
+        end
+      end
+    end
+  end
+
   it 'generates backend stanza without cookies for tcp mode' do
     mockConfig = ['mode tcp']
     expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", ["\tmode tcp"], ["\tserver somehost:5555 somehost:5555 check inter 2000 rise 3 fall 2"]])


### PR DESCRIPTION
Currently we are doing shuffling (random ordering) only because we wanted to load
balance with round-robin to be more even across all machines.

This option allows one to specify how backends are ordered
in the final backend stanza configuration. This make it possible to support
usages that require an identical backend stanza configuration across machines.

@igor47  @jolynch  

cc @scarletmeow