### PR TITLE
zookeeper_dns is broken

### DIFF
--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'synapse/service_watcher/zookeeper'
+require 'synapse/service_watcher/zookeeper_dns'
+
+describe Synapse::ServiceWatcher::ZookeeperWatcher do
+  let(:mock_synapse) { double }
+  let(:config) do
+    {
+      'name' => 'test',
+      'haproxy' => {},
+      'discovery' => discovery,
+    }
+  end
+
+  let(:service_data) do
+    {
+      'host' => 'server',
+      'port' => '8888',
+      'name' => 'server',
+      'weight' => '1',
+      'haproxy_server_options' => 'backup',
+      'labels' => { 'az' => 'us-east-1a' }
+    }
+  end
+  let(:service_data_string) { service_data.to_json }
+  let(:deserialized_service_data) {
+    [ service_data['host'], service_data['port'], service_data['name'], service_data['weight'],
+      service_data['haproxy_server_options'], service_data['labels'] ]
+  }
+
+  context 'ZookeeperWatcher' do
+    let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost','path' => 'some/path' } }
+    subject { Synapse::ServiceWatcher::ZookeeperWatcher.new(config, mock_synapse) }
+    it 'decodes data correctly' do
+      expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
+    end
+  end
+
+  context 'ZookeeperDnsWatcher' do
+    let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => 'somehost','path' => 'some/path' } }
+    let(:message_queue) { [] }
+    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, message_queue) }
+    it 'decodes data correctly' do
+      expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
+    end
+  end
+end


### PR DESCRIPTION
While testing the new release of synapse v0.13.0, I noticed that the zookeeper_dns discovery method was failing with the following error:

```
E, [2016-02-17T22:03:58.722362 #10392] ERROR -- 
Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper: synapse: invalid data in ZK node 
example-service at /production/services/example-service/services: undefined method `call' for 
nil:NilClass
```

The root cause is that `@decode_method` is not properly initialized for the class, since it is initialized in `validate_discovery_opts` which is overwritten in ZookeeperDNSWatcher::Zookeeper. We can't call `super` since it's valid for the discovery method to be `zookeeper`.

There's probably a more elegant fix, let me think about it. The other issue is if we should yank v0.13.0 of synapse since it is broken for this discovery method.

@SonicWang @igor47 @jolynch 