### PR TITLE
Permit to hash servernames in affinity cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ This section is its own hash, which should contain the following keys:
 * `listen`: these lines will be parsed and placed in the correct `frontend`/`backend` section as applicable; you can put lines which are the same for the frontend and backend here.
 * `backend_order`: optional: how backends should be ordered in the `backend` stanza. (default is shuffling). Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza. `desc` means descending alphabetical order. `no_shuffle` means no shuffling or sorting.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
+* `cookie_value_method`: optional: default value is `name`, it defines the way your backends receive a cookie value in http mode. If equal to `hash`, synapse hashes backend names on cookie value assignation of your discovered backends, useful when you want to use haproxy cookie feature but you do not want that your end users receive a Set-Cookie with your server name and ip readable in clear.
 
 <a name="haproxy"/>
 ### Configuring HAProxy ###

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -23,6 +23,15 @@ describe Synapse::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_with_cookie_value_method_hash) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    backends = [{ 'host' => 'somehost', 'port' => 5555}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2", 'cookie_value_method' => 'hash'})
+    mockWatcher
+  end
+
   let(:mockwatcher_frontend) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service')
@@ -74,6 +83,11 @@ describe Synapse::Haproxy do
         end
       end
     end
+  end
+
+  it 'hashes backend name as cookie value' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_value_method_hash, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'generates backend stanza without cookies for tcp mode' do


### PR DESCRIPTION
Hi, this PR replace : https://github.com/airbnb/synapse/pull/165

Sorry again.

Tony