### PR TITLE
[issue-172:dns] Gracefully fail DNS resolver interruptions

### DIFF
--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -15,7 +15,13 @@ class Synapse::ServiceWatcher
     end
 
     def ping?
-      @watcher.alive? && !(resolver.getaddresses('airbnb.com').empty?)
+      begin
+        @watcher.alive? && !(resolver.getaddresses('airbnb.com').empty?)
+      rescue => e
+        log.warn "Name server error: #{e.inspect}"
+        log.warn e.backtrace
+        false
+      end
     end
 
     def discovery_servers


### PR DESCRIPTION
Relates to https://github.com/airbnb/synapse/issues/172.

Synapse crashes if it can't resolve airbnb.com,  the specific exception not handled is RuntimeError.  I personally don't care that the resolver check is hard-coded to airbnb.com.  I also get that synapse is designed to be fail fast.  However this fail fast approach has an interesting side effect in certain use cases. 

We were testing a pre-production Mesos cluster with synapse as our service discovery layer.  We temporarily lost the ability to resolve DNS and synapse crashed on resolution failure.  Normally this isn't a big deal.  

We are also using Apache Aurora (aka TwitterScheduler) for Mesos and we are running synapse as a process member of the job's task.  Under Aurora/Thermos if a single process exits non-zero the whole task fails.  Normally this isn't a big deal either.

However since DNS resolution was interrupted, and synapse bailed on resolving 'airbnb.com' (every synapse process through the fleet failed within seconds of each other.  This caused every Task that synapse (using zookeeper_dns) was part of to fail.  This in turn caused every instance of each Job to fail.  This of course caused the jobs to be rescheduled.  Had this been a production sized cluster, we would have crushed the storage layer of our stack.