### PR TITLE
Feat fix test failure on glob

### DIFF
--- a/spec/lib/synapse/file_output_spec.rb
+++ b/spec/lib/synapse/file_output_spec.rb
@@ -35,7 +35,7 @@ describe Synapse::FileOutput do
   it 'manages correct files' do
     subject.update_config([mockwatcher_1, mockwatcher_2])
     FileUtils.cd(config['file_output']['output_directory']) do
-      expect(Dir.glob('*.json')).to eql(['example_service.json', 'foobar_service.json'])
+      expect(Dir.glob('*.json').sort).to eql(['example_service.json', 'foobar_service.json'])
     end
     # Should clean up after itself
     subject.update_config([mockwatcher_1])


### PR DESCRIPTION
Hi,

I have tried to fix a test which breaks on my system due to the order of files returned by glob.
I am running:

> Linux debian 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt20-1+deb8u2 (2016-01-02) x86_64 GNU/Linux

Ruby doc says that files order returned by glob is system dependent. It is problematic for just this test since this is the only one which return 2 elements.

It should be now fixed for all systems.
Regards.

Tony



