### PR TITLE
label_filter support for zookeeper_dns

### DIFF
--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -85,6 +85,7 @@ class Synapse::ServiceWatcher
             'host' => address,
             'port' => server['port'],
             'name' => server['name'],
+            'labels' => server['labels'],
           }
         end
       end

--- a/lib/synapse/service_watcher/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns.rb
@@ -129,11 +129,11 @@ class Synapse::ServiceWatcher
 
     def start
       dns_discovery_opts = @discovery.select do |k,_|
-        k == 'nameserver'
+        k == 'nameserver' || k == 'label_filter'
       end
 
       zookeeper_discovery_opts = @discovery.select do |k,_|
-        k == 'hosts' || k == 'path'
+        k == 'hosts' || k == 'path' || k == 'label_filter'
       end
 
       @check_interval = @discovery['check_interval'] || 30.0


### PR DESCRIPTION
Extends `label_filter` functionality for `ZookeeperDnsWatcher`. This requires a change to `ZookeeperDnsWatcher` to forward the discovery options for label filtering and a change to `DnsWatcher` to pass a long any server `labels`.

Tested that label functionality is working for `ZookeeperDnsWatcher` with this patchset.

to: @SonicWang @igor47 @jolynch 