### PR TITLE
Haproxy tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
+    timecop (0.8.1)
     webmock (1.22.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -82,7 +83,8 @@ DEPENDENCIES
   rake
   rspec (~> 3.1.0)
   synapse!
+  timecop
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -6,7 +6,7 @@ require 'digest/sha1'
 module Synapse
   class Haproxy
     include Logging
-    attr_reader :opts, :name
+    attr_reader :opts
 
     # these come from the documentation for haproxy 1.5
     # http://haproxy.1wt.eu/download/1.5/doc/configuration.txt
@@ -531,7 +531,6 @@ module Synapse
       end
 
       @opts = opts
-      @name = 'haproxy'
 
       @opts['do_writes'] = true unless @opts.key?('do_writes')
       @opts['do_socket'] = true unless @opts.key?('do_socket')
@@ -564,6 +563,10 @@ module Synapse
           @seen = {}
         end
       end
+    end
+
+    def name
+      'haproxy'
     end
 
     def tick(watchers)

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -10,7 +10,7 @@ module Synapse
 
     # these come from the documentation for haproxy 1.5
     # http://haproxy.1wt.eu/download/1.5/doc/configuration.txt
-    @@section_fields = {
+    SECTION_FIELDS = {
       "backend" => [
         "acl",
         "appsession",
@@ -510,7 +510,7 @@ module Synapse
         "use_backend",
         "use-server"
       ]
-    }
+    }.freeze
 
     def initialize(opts)
       super()
@@ -665,7 +665,7 @@ module Synapse
         config[section].concat(
           watcher.haproxy['listen'].select {|setting|
             parsed_setting = setting.strip.gsub(/\s+/, ' ').downcase
-            @@section_fields[section].any? {|field| parsed_setting.start_with?(field)}
+            SECTION_FIELDS[section].any? {|field| parsed_setting.start_with?(field)}
           })
 
         # pick only those fields that are valid and warn about the invalid ones
@@ -678,7 +678,7 @@ module Synapse
     def validate_haproxy_stanza(stanza, stanza_type, service_name)
       return stanza.select {|setting|
         parsed_setting = setting.strip.gsub(/\s+/, ' ').downcase
-        if @@section_fields[stanza_type].any? {|field| parsed_setting.start_with?(field)}
+        if SECTION_FIELDS[stanza_type].any? {|field| parsed_setting.start_with?(field)}
           true
         else
           log.warn "synapse: service #{service_name} contains invalid #{stanza_type} setting: '#{setting}', discarding"

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -512,6 +512,8 @@ module Synapse
       ]
     }.freeze
 
+    STATE_FILE_UPDATE_INTERVAL = 60.freeze # iterations; not a unit of time
+
     def initialize(opts)
       super()
 
@@ -570,7 +572,7 @@ module Synapse
     end
 
     def tick(watchers)
-      if @time % 60 == 0 && !@state_file_path.nil?
+      if (@time % STATE_FILE_UPDATE_INTERVAL) == 0
         update_state_file(watchers)
       end
 
@@ -891,8 +893,10 @@ module Synapse
     end
 
     def update_state_file(watchers)
-      log.info "synapse: writing state file"
+      # if we don't support the state file, do nothing
+      return if @state_file_path.nil?
 
+      log.info "synapse: writing state file"
       timestamp = Time.now.to_i
 
       # Remove stale backends

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -16,7 +16,7 @@ describe Synapse::Haproxy do
 
   let(:mockwatcher_with_server_options) do
     mockWatcher = double(Synapse::ServiceWatcher)
-    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:name).and_return('example_service2')
     backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_options' => 'backup'}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
     allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2"})
@@ -25,7 +25,7 @@ describe Synapse::Haproxy do
 
   let(:mockwatcher_with_cookie_value_method_hash) do
     mockWatcher = double(Synapse::ServiceWatcher)
-    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:name).and_return('example_service3')
     backends = [{ 'host' => 'somehost', 'port' => 5555}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
     allow(mockWatcher).to receive(:haproxy).and_return({'server_options' => "check inter 2000 rise 3 fall 2", 'cookie_value_method' => 'hash'})
@@ -34,14 +34,14 @@ describe Synapse::Haproxy do
 
   let(:mockwatcher_frontend) do
     mockWatcher = double(Synapse::ServiceWatcher)
-    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:name).and_return('example_service4')
     allow(mockWatcher).to receive(:haproxy).and_return('port' => 2200)
     mockWatcher
   end
 
   let(:mockwatcher_frontend_with_bind_address) do
     mockWatcher = double(Synapse::ServiceWatcher)
-    allow(mockWatcher).to receive(:name).and_return('example_service')
+    allow(mockWatcher).to receive(:name).and_return('example_service5')
     allow(mockWatcher).to receive(:haproxy).and_return('port' => 2200, 'bind_address' => "127.0.0.3")
     mockWatcher
   end
@@ -169,7 +169,7 @@ describe Synapse::Haproxy do
 
   it 'hashes backend name as cookie value' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_value_method_hash, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
+    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_value_method_hash, mockConfig)).to eql(["\nbackend example_service3", [], ["\tserver somehost:5555 somehost:5555 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'generates backend stanza without cookies for tcp mode' do
@@ -179,17 +179,17 @@ describe Synapse::Haproxy do
 
   it 'respects haproxy_server_options' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
+    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
   end
 
   it 'generates frontend stanza ' do
     mockConfig = []
-    expect(subject.generate_frontend_stanza(mockwatcher_frontend, mockConfig)).to eql(["\nfrontend example_service", [], "\tbind localhost:2200", "\tdefault_backend example_service"])
+    expect(subject.generate_frontend_stanza(mockwatcher_frontend, mockConfig)).to eql(["\nfrontend example_service4", [], "\tbind localhost:2200", "\tdefault_backend example_service4"])
   end
 
   it 'respects frontend bind_address ' do
     mockConfig = []
-    expect(subject.generate_frontend_stanza(mockwatcher_frontend_with_bind_address, mockConfig)).to eql(["\nfrontend example_service", [], "\tbind 127.0.0.3:2200", "\tdefault_backend example_service"])
+    expect(subject.generate_frontend_stanza(mockwatcher_frontend_with_bind_address, mockConfig)).to eql(["\nfrontend example_service5", [], "\tbind 127.0.0.3:2200", "\tdefault_backend example_service5"])
   end
 
 end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -46,6 +46,11 @@ describe Synapse::Haproxy do
     mockWatcher
   end
 
+  describe '#name' do
+    it 'returns haproxy' do
+      expect(subject.name).to eq('haproxy')
+    end
+  end
 
   it 'updating the config' do
     expect(subject).to receive(:generate_config)

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -125,6 +125,15 @@ describe Synapse::Haproxy do
     end
   end
 
+  describe '#tick' do
+    it 'updates the state file at regular intervals' do
+      expect(subject).to receive(:update_state_file).twice
+      (described_class::STATE_FILE_UPDATE_INTERVAL + 1).times do
+        subject.tick({})
+      end
+    end
+  end
+
   it 'generates backend stanza' do
     mockConfig = []
     expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require 'pry'
 require 'support/configuration'
 require 'webmock/rspec'
 
+# configure timecop
+require 'timecop'
+Timecop.safe_mode = true
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "webmock"
+  gem.add_development_dependency "timecop"
 end


### PR DESCRIPTION
This PR contains no functional changes to Synapse. Instead, it adds a bunch of tests for the Haproxy class. We refactor the Haproxy class slightly to make testing easier. The main goal was to cover the state file handling with tests, since we're about to start using the state file at Airbnb. No bugs were found!

Ideally, we would only test the public methods of Haproxy -- `initialize`, `tick`, and `update_config`. however, if I set all of the other methods to private, we fail lots of existing tests, and testing the deep functionality of Haproxy via the public interface seems very tedious. So, although I intended to make that change here, I decided to save it for some other time.

to: @jolynch @scarletmeow 