### PR TITLE
Bump Gemfile.lock to fix specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.13.2)
+    synapse (0.13.3)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       logging (~> 1.8)


### PR DESCRIPTION
Synapse version in Gemfile.lock needs to get bumped. My guess is this is some kind of interaction with Travis and `--deployment` being enabled because we have a Gemfile.lock in the repository. Anything other than the current version will trigger an error similar to `Could not find synapse-0.13.2 in any of the sources`

to: @igor47