### PR TITLE
Clean up HAProxy sockets after reading

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1035,9 +1035,7 @@ module Synapse
       s.write(command)
       info = s.read
     ensure
-      if s
-        s.close
-      end
+      s.close if s
     end
 
     # tries to set active backends via haproxy's stats socket

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1033,7 +1033,7 @@ module Synapse
     def haproxy_exec(command)
       s = UNIXSocket.new(@opts['socket_file_path'])
       s.write(command)
-      info = s.read
+      s.read
     ensure
       s.close if s
     end


### PR DESCRIPTION
HAProxy closes its connection to the socket as soon as it finishes writing. This PR explicitly closes the socket from the synapse side. Without an explicit close, cleanup done on object finalization during garbage collection. This can cause synapse to temporarily accumulate a large number of socket file descriptors.

On a synthetic test with a large number of backends, this patch reduces the maximum number of open file descriptors from 940 to 52.

There are minor logging changes associated with this patch:
* added logging of error if an exception is raised when closing the file.
* if reading from the socket fails when called from https://github.com/airbnb/synapse/compare/master...brianwolfe:wolfe-socket-fd-cleanup?expand=1#diff-b2f6400f899968d5a5084ee66bf90b21R1106, there will be 2 error messages raised instead of 1, one message for the failure to read, one message for the failed command. Previously, only the failure to read error would be logged.

For old ruby versions, this cleanup can avoid this issue: https://bugs.ruby-lang.org/issues/8080 where glibc FORTIFY_SOURCE chokes on more than 1024 file descriptors despite linux supporting more.

@igor47 