### PR TITLE
Multiple stats sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ The top level `haproxy` section of the config file has the following options:
 * `do_writes`: whether or not the config file will be written (default to `true`)
 * `do_reloads`: whether or not Synapse will reload HAProxy (default to `true`)
 * `do_socket`: whether or not Synapse will use the HAProxy socket commands to prevent reloads (default to `true`)
+* `socket_file_path`: where to find the haproxy stats socket. can be a list (if using `nbproc`)
 * `global`: options listed here will be written into the `global` section of the HAProxy config
 * `defaults`: options listed here will be written into the `defaults` section of the HAProxy config
 * `extra_sections`: additional, manually-configured `frontend`, `backend`, or `listen` stanzas
@@ -332,7 +333,9 @@ For example:
    - "bind 127.0.0.1:8081"
   reload_command: "service haproxy reload"
   config_file_path: "/etc/haproxy/haproxy.cfg"
-  socket_file_path: "/var/run/haproxy.sock"
+  socket_file_path:
+    - /var/run/haproxy.sock
+    - /var/run/haproxy2.sock
   global:
    - "daemon"
    - "user    haproxy"

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -1119,7 +1119,7 @@ module Synapse
         end
       end
 
-      log.info "synapse: reconfigured haproxy"
+      log.info "synapse: reconfigured haproxy via #{socket_file_path}"
     end
 
     # writes the config

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -815,6 +815,10 @@ module Synapse
       @opts['do_socket'] = true unless @opts.key?('do_socket')
       @opts['do_reloads'] = true unless @opts.key?('do_reloads')
 
+      # socket_file_path can be a string or a list
+      # lets make a new option which is always a list (plural)
+      @opts['socket_file_paths'] = [@opts['socket_file_path']].flatten
+
       # how to restart haproxy
       @restart_interval = @opts.fetch('restart_interval', 2).to_i
       @restart_jitter = @opts.fetch('restart_jitter', 0).to_f


### PR DESCRIPTION
we are running into haproxy CPU bottlenecks on some boxes. to get around those, we would like to run haproxy on multiple CPUs via `nbproc`. this PR enables the simplest way to configure `nbproc`, where all backends are listening on all processes and share the load. here is an example synapse config snapshot which would result in the desired behavior:

```json
{
  
  "haproxy": {
    "socket_file_path": [
      "/var/haproxy/stats1.sock",
      "/var/haproxy/stats2.sock",
    ],
    "global": [
      "nbproc 2",
      "cpu-map 1 0",
      "stats socket /var/haproxy/stats1.sock group smartstack mode 660 level admin process 1",
      "cpu-map 2 1",
      "stats socket /var/haproxy/stats2.sock group smartstack mode 660 level admin process 2",
```

this creates two independent haproxy processes, each with their own socket. we also tell synapse that two socket file paths exist. synapse will attempt to independently configure all of the processes via the stats socket, and will resort to restarting haproxy if we cannot dynamically configure either of them.

to: @nwadams @jtai 
cc: @jolynch @scarletmeow 