### PR TITLE
WIP: Standalone mode

### DIFF
--- a/bin/synapse_standalone
+++ b/bin/synapse_standalone
@@ -8,4 +8,4 @@ watcher = Synapse::ServiceWatcher.create('', {
   'haproxy' => {},
 }, {})
 watcher.start(initial_discover: false)
-puts JSON.pretty_generate(watcher.read_zk)
+puts JSON.pretty_generate(watcher.read)

--- a/bin/synapse_standalone
+++ b/bin/synapse_standalone
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+require "json"
+require "synapse/service_watcher"
+
+service_data = JSON.parse(ARGV[0])
+watcher = Synapse::ServiceWatcher.create('', {
+  "discovery" => service_data,
+  'haproxy' => {},
+}, {})
+watcher.start(initial_discover: false)
+puts JSON.pretty_generate(watcher.read_zk)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -29,7 +29,7 @@ class Synapse::ServiceWatcher
       end
     end
 
-    def start(initial_discover=true)
+    def start(initial_discover: true)
       @zk_hosts = @discovery['hosts'].sort.join(',')
 
       @watcher = nil

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -29,14 +29,14 @@ class Synapse::ServiceWatcher
       end
     end
 
-    def start
+    def start(initial_discover=true)
       @zk_hosts = @discovery['hosts'].sort.join(',')
 
       @watcher = nil
       @zk = nil
 
       log.info "synapse: starting ZK watcher #{@name} @ hosts: #{@zk_hosts}, path: #{@discovery['path']}"
-      zk_connect
+      zk_connect(initial_discover)
     end
 
     def stop
@@ -48,6 +48,34 @@ class Synapse::ServiceWatcher
       # @zk being nil implies no session *or* a lost session, do not remove
       # the check on @zk being truthy
       @zk && @zk.connected?
+    end
+
+    def read_zk
+      new_backends = []
+      @zk.children(@discovery['path'], :watch => true).each do |id|
+        node = @zk.get("#{@discovery['path']}/#{id}")
+
+        begin
+          # TODO: Do less munging, or refactor out this processing
+          host, port, name, weight, haproxy_server_options, labels = deserialize_service_instance(node.first)
+        rescue StandardError => e
+          log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
+        else
+          server_port = @haproxy['server_port_override'] ? @haproxy['server_port_override'] : port
+
+          # find the numberic id in the node name; used for leader elections if enabled
+          numeric_id = id.split('_').last
+          numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
+
+          log.debug "synapse: discovered backend #{name} at #{host}:#{server_port} for service #{@name}"
+          new_backends << {
+            'name' => name, 'host' => host, 'port' => server_port,
+            'id' => numeric_id, 'weight' => weight,
+            'haproxy_server_options' => haproxy_server_options,
+            'labels' => labels
+          }
+        end
+      end
     end
 
     private
@@ -124,33 +152,7 @@ class Synapse::ServiceWatcher
     # find the current backends at the discovery path
     def discover
       log.info "synapse: discovering backends for service #{@name}"
-
-      new_backends = []
-      @zk.children(@discovery['path'], :watch => true).each do |id|
-        node = @zk.get("#{@discovery['path']}/#{id}")
-
-        begin
-          # TODO: Do less munging, or refactor out this processing
-          host, port, name, weight, haproxy_server_options, labels = deserialize_service_instance(node.first)
-        rescue StandardError => e
-          log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
-        else
-          server_port = @haproxy['server_port_override'] ? @haproxy['server_port_override'] : port
-
-          # find the numberic id in the node name; used for leader elections if enabled
-          numeric_id = id.split('_').last
-          numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
-
-          log.debug "synapse: discovered backend #{name} at #{host}:#{server_port} for service #{@name}"
-          new_backends << {
-            'name' => name, 'host' => host, 'port' => server_port,
-            'id' => numeric_id, 'weight' => weight,
-            'haproxy_server_options' => haproxy_server_options,
-            'labels' => labels
-          }
-        end
-      end
-
+      new_backends = read_zk
       set_backends(new_backends)
     end
 
@@ -206,7 +208,7 @@ class Synapse::ServiceWatcher
       log.info "synapse: zookeeper watcher cleaned up successfully"
     end
 
-    def zk_connect
+    def zk_connect(initial_discover)
       log.info "synapse: zookeeper watcher connecting to ZK at #{@zk_hosts}"
 
       # Ensure that all Zookeeper watcher re-use a single zookeeper
@@ -236,8 +238,10 @@ class Synapse::ServiceWatcher
       # the path must exist, otherwise watch callbacks will not work
       create(@discovery['path'])
 
-      # call the callback to bootstrap the process
-      watcher_callback.call
+      if initial_discover
+        # call the callback to bootstrap the process
+        watcher_callback.call
+      end
     end
 
     # decode the data at a zookeeper endpoint

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -50,7 +50,7 @@ class Synapse::ServiceWatcher
       @zk && @zk.connected?
     end
 
-    def read_zk
+    def read
       @zk.children(@discovery['path'], :watch => true).collect do |id|
         node = @zk.get("#{@discovery['path']}/#{id}")
 
@@ -152,7 +152,7 @@ class Synapse::ServiceWatcher
     # find the current backends at the discovery path
     def discover
       log.info "synapse: discovering backends for service #{@name}"
-      new_backends = read_zk
+      new_backends = read
       set_backends(new_backends)
     end
 


### PR DESCRIPTION
@jolynch: this branch implements something we had discussed a little while ago, namely a standalone or "oneshot" execution mode for Synapse. This is for situations where you would like to know what information is in Synapse's backing datastore, but you don't want to read it out of the datastore directly in order to preserve separation of concerns. By adding this standalone operation, we can use the same code paths that Synapse would use to read the data.

My initial use-case is monitoring scripts. I would like to deploy a container with the Synapse gem, and run it as a script that produces a list of backends as output. My monitoring script will process this output, check it for sanity, and report issues to my monitoring system if the results are insane.

This change makes use of a new method on watchers, that I've called `read`. As far as I can tell, right now watchers don't implement any method which provides the list of backends as output without mutating other state. `read` is designed for that purpose.

So far I've just touched the Zookeeper watcher. Please review for initial feasibility.

Example invocation:
```
synapse_standalone.rb '{"method":"zookeeper","path":"/nerve/services/postgres_main_read","hosts":["10.74.4.104:2181","10.74.4.70:2181","10.74.1.43:2181"]}'
```