### PR TITLE
Refactor label filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.2.6)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.4.0)
     aws-sdk (1.66.0)
       aws-sdk-v1 (= 1.66.0)
@@ -24,8 +30,11 @@ GEM
       excon (>= 0.38.0)
       json
     excon (0.45.4)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
     ffi (1.9.10-java)
     hashdiff (0.2.3)
+    i18n (0.7.0)
     json (1.8.3)
     little-plugger (1.1.3)
     logging (1.8.2)
@@ -33,6 +42,7 @@ GEM
       multi_json (>= 1.8.4)
     method_source (0.8.2)
     mini_portile2 (2.0.0)
+    minitest (5.9.0)
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -64,7 +74,10 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
+    thread_safe (0.3.5)
     timecop (0.8.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     webmock (1.22.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -78,6 +91,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  factory_girl
   pry
   pry-nav
   rake

--- a/README.md
+++ b/README.md
@@ -152,16 +152,17 @@ The base watcher is useful in situations where you only want to use the servers 
 It has the following options:
 
 * `method`: base
-* `label_filter`: optional filter to be applied to discovered service nodes
+* `label_filters`: optional list of filters to be applied to discovered service nodes
 
 ###### Filtering service nodes ######
-Synapse can be configured to only return service nodes that match a `label_filter` predicate. If provided, the `label_filter` hash should contain the following:
 
-* `label`: The label for which the filter is applied
+Synapse can be configured to only return service nodes that match a `label_filters` predicate. If provided, `label_filters` should be an array of hashes which contain the following:
+
+* `label`: The name of the label for which the filter is applied
 * `value`: The comparison value
-* `condition` (one of ['`equals`']): The type of filter condition to be applied. Only `equals` is supported at present
+* `condition` (one of ['`equals`', '`not-equals`']): The type of filter condition to be applied.
 
-Given a `label_filter`: `{ "label": "cluster", "value": "dev", "condition": "equals" }`, this will return only service nodes that contain the label value `{ "cluster": "dev" }`.
+Given a `label_filters`: `[{ "label": "cluster", "value": "dev", "condition": "equals" }]`, this will return only service nodes that contain the label value `{ "cluster": "dev" }`.
 
 ##### Zookeeper #####
 

--- a/spec/factories/backend.rb
+++ b/spec/factories/backend.rb
@@ -1,0 +1,20 @@
+FactoryGirl.define do
+  factory :backend, :class => Hash do
+    sequence(:name) { |n| "server#{n}" }
+    sequence(:host) { |n| "hostname#{n}" }
+    sequence(:port)
+
+    labels  {}
+
+    # needed to build hashes instead of classes
+    initialize_with { attributes }
+
+    # convert keys to strings, since backends always have string keys
+    after(:build) do |backend|
+      backend.keys.each do |k|
+        backend[k.to_s] = backend[k]
+        backend.delete(k)
+      end
+    end
+  end
+end

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -111,17 +111,25 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     end
 
     context 'with label_filter set' do
-      let(:matching_labeled_backends) { [
-        { 'name' => 'server1', 'host' => 'server1', 'port' => 1111, 'labels' => { 'az' => 'us-east-1a' } },
-        { 'name' => 'server2', 'host' => 'server2', 'port' => 2222, 'labels' => { 'az' => 'us-east-1a' } },
-      ] }
-      let(:non_matching_labeled_backends) { [
-        { 'name' => 'server3', 'host' => 'server3', 'port' => 3333, 'labels' => { 'az' => 'us-west-1c' } },
-        { 'name' => 'server4', 'host' => 'server4', 'port' => 4444, 'labels' => { 'az' => 'us-west-2a' } },
-      ] }
-      let(:non_labeled_backends) { [
-        { 'name' => 'server5', 'host' => 'server5', 'port' => 5555 },
-      ] }
+      let(:matching_az) { 'us-east-1a' }
+      let(:matching_labels) { [{'az' => matching_az}] * 2 }
+      let(:non_matching_labels) { [{'az' => 'us-east-1b'}, {'az' => 'us-west-1a'}] }
+
+      let(:matching_labeled_backends) do
+        matching_labels.map{ |l| FactoryGirl.build(:backend, :labels => l) }
+      end
+      let(:non_matching_labeled_backends) do
+        non_matching_labels.map{ |l| FactoryGirl.build(:backend, :labels => l) }
+      end
+      let(:non_labeled_backends) do
+        [FactoryGirl.build(:backend, :labels => {})]
+      end
+
+      before do
+        expect(subject).to receive(:'reconfigure!').exactly(:once)
+        subject.send(:set_backends,
+          matching_labeled_backends + non_matching_labeled_backends + non_labeled_backends)
+      end
 
       let(:condition) { 'equals' }
       let(:label_filters) { [{ 'condition' => condition, 'label' => 'az', 'value' => 'us-east-1a' }] }
@@ -135,9 +143,6 @@ describe Synapse::ServiceWatcher::BaseWatcher do
       end
 
       it 'removes all backends that do not match the label_filter' do
-        expect(subject).to receive(:'reconfigure!').exactly(:once)
-        subject.send(:set_backends, matching_labeled_backends + non_matching_labeled_backends +
-                     non_labeled_backends)
         expect(subject.backends).to contain_exactly(*matching_labeled_backends)
       end
 
@@ -145,16 +150,21 @@ describe Synapse::ServiceWatcher::BaseWatcher do
         let(:condition) { 'not-equals' }
 
         it 'removes all backends that DO match the label_filter' do
-          expect(subject).to receive(:'reconfigure!').exactly(:once)
-          subject.send(:set_backends, matching_labeled_backends + non_matching_labeled_backends +
-                       non_labeled_backends)
           expect(subject.backends).to contain_exactly(*(non_labeled_backends + non_matching_labeled_backends))
         end
       end
 
-      context 'with multiple conditions' do
-        let(:matching_az) { 'az1' }
+      context 'with multiple labels and conditions conditions' do
         let(:matching_region) { 'region1' }
+        let(:matching_labels) { [{'az' => matching_az, 'region' => matching_region}] * 2 }
+        let(:non_matching_labels) do
+          [
+            {'az' => matching_az, 'region' => 'non-matching'},
+            {'az' => 'non-matching', 'region' => matching_region},
+            {'az' => 'non-matching', 'region' => 'non-matching'},
+          ]
+        end
+
         let(:label_filters) do
           [
             { 'condition' => 'equals', 'label' => 'az', 'value' => matching_az },
@@ -162,25 +172,8 @@ describe Synapse::ServiceWatcher::BaseWatcher do
           ]
         end
 
-        let(:matching_labels) { [{'az' => matching_az, 'region' => matching_region}] * 2 }
-        let(:non_matching_labels) do [
-            {},
-            {'az' => matching_az, 'region' => 'non-matching'},
-            {'az' => 'non-matching', 'region' => matching_region},
-            {'az' => 'non-matching', 'region' => 'non-matching'},
-          ] end
-
-        let(:matching_backends) do
-          matching_labels.map{ |l| FactoryGirl.build(:backend, :labels => l) }
-        end
-        let(:non_matching_backends) do
-          non_matching_labels.map{ |l| FactoryGirl.build(:backend, :labels => l) }
-        end
-
         it 'returns only backends that match all labels' do
-          expect(subject).to receive(:'reconfigure!').exactly(:once)
-          subject.send(:set_backends, matching_backends + non_matching_backends)
-          expect(subject.backends).to contain_exactly(*matching_backends)
+          expect(subject.backends).to contain_exactly(*matching_labeled_backends)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,16 @@ require 'webmock/rspec'
 require 'timecop'
 Timecop.safe_mode = true
 
+# configure factory girl
+require 'factory_girl'
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+  config.before(:suite) do
+    FactoryGirl.find_definitions
+  end
+end
+
+# general RSpec config
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1.0"
+  gem.add_development_dependency "factory_girl"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "webmock"


### PR DESCRIPTION
In this PR, we make the following changes:

* go from `label_filter` to `label_filters` -- this allows us to define multiple filters, which must ALL match
* add a new filter condition, for `not-equals`
* allow leader election to operate on filtered backends, thus making leader election and filters no longer mutually exclusive (the mutual exclusivity was not documented)

this covers our main use case -- utilize only backends in the current region and the current az (the default case), or utilize only backends in the current region and NOT the current az (in case of AZ failover).

as well, we refactor the specs for labels to use a factory to create the labels, vs creating hashes manually and being forced to specify a bunch of attributes we don't care about.

to: @jolynch @scarletmeow @nwadams 
cc: @jtai 