### PR TITLE
comment line was breaking config comparison

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -866,7 +866,9 @@ module Synapse
 
       # if we write config files, lets do that and then possibly restart
       if @opts['do_writes']
-        write_config(new_config)
+        unless write_config(new_config)
+          @restart_required = false
+        end
         restart if @opts['do_reloads'] && @restart_required
       end
     end
@@ -1131,7 +1133,8 @@ module Synapse
         old_config = ""
       end
 
-      if old_config == new_config
+      if old_config.split("\n")[1..-1].join == new_config.split("\n")[1..-1].join
+        log.info "synapse: new config is identical to existing haproxy config file."
         return false
       else
         File.open(@opts['config_file_path'],'w') {|f| f.write(new_config)}

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -866,9 +866,7 @@ module Synapse
 
       # if we write config files, lets do that and then possibly restart
       if @opts['do_writes']
-        unless write_config(new_config)
-          @restart_required = false
-        end
+        @restart_required = false if write_config(new_config) == false
         restart if @opts['do_reloads'] && @restart_required
       end
     end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -57,12 +57,7 @@ describe Synapse::Haproxy do
 
     shared_context 'generate_config is stubbed out' do
       let(:new_config) { 'this is a new config!' }
-      let(:old_config) { 'this is a old config!' }
-
-      before do 
-        allow(File).to receive(:read).and_return(old_config)        
-        expect(subject).to receive(:generate_config).and_return(new_config)
-      end
+      before { expect(subject).to receive(:generate_config).and_return(new_config) }
     end
 
     it 'always updates the config' do

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -57,7 +57,12 @@ describe Synapse::Haproxy do
 
     shared_context 'generate_config is stubbed out' do
       let(:new_config) { 'this is a new config!' }
-      before { expect(subject).to receive(:generate_config).and_return(new_config) }
+      let(:old_config) { 'this is a old config!' }
+
+      before do 
+        allow(File).to receive(:read).and_return(old_config)        
+        expect(subject).to receive(:generate_config).and_return(new_config)
+      end
     end
 
     it 'always updates the config' do


### PR DESCRIPTION
Due to the auto-generated comment line included on the first line of the HAProxy, a restart of HAProxy will occur even when the configuration itself is identical.

Here is an example diff when no configuration has actually changed:
```
1c1
< # auto-generated by synapse at 2016-08-24 10:20:55 +0000
---
> # auto-generated by synapse at 2016-08-24 10:22:47 +0000
```
As the logic to decide whether or not the config is different is just a simple string comparison (within the write_config function) it will never return true.