### PR TITLE
Add splay startup jitter to haproxy startup

### DIFF
--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -826,7 +826,7 @@ module Synapse
 
       # virtual clock bookkeeping for controlling how often haproxy restarts
       @time = 0
-      @next_restart = @time
+      @next_restart = rand(@restart_jitter * @restart_interval + 1)
 
       # a place to store the parsed haproxy config from each watcher
       @watcher_configs = {}


### PR DESCRIPTION
Sometimes all the synapses are restarted globally across a fleet, so I would like their startup to be jittered just like their normal `next_restart` is jittered during a normal haproxy restart. I believe this change will do that.
