### PR TITLE
Adding additional bind_options param to support ssl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ This section is its own hash, which should contain the following keys:
 
 * `port`: the port (on localhost) where HAProxy will listen for connections to the service. If this is omitted, only a backend stanza (and no frontend stanza) will be generated for this service; you'll need to get traffic to your service yourself via the `shared_frontend` or manual frontends in `extra_sections`
 * `bind_address`: force HAProxy to listen on this address ( default is localhost ). Setting `bind_address` on a per service basis overrides the global `bind_address` in the top level `haproxy`. Having HAProxy listen for connections on different addresses ( example: service1 listen on 127.0.0.2:443 and service2 listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
+* `bind_options`: optional: default value is an empty string, specify additional bind parameters, such as ssl accept-proxy, crt, ciphers etc.
 * `server_port_override`: the port that discovered servers listen on; you should specify this if your discovery mechanism only discovers names or addresses (like the DNS watcher). If the discovery method discovers a port along with hostnames (like the zookeeper watcher) this option may be left out, but will be used in preference if given.
 * `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out.
 * `frontend`: additional lines passed to the HAProxy config in the `frontend` stanza of this service

--- a/config/synapse.conf.json
+++ b/config/synapse.conf.json
@@ -18,6 +18,7 @@
       "haproxy": {
         "port": 3213,
         "server_options": "check inter 2s rise 3 fall 2",
+        "bind_options": "ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305",
         "listen": [
           "mode http",
           "option httpchk /health",

--- a/lib/synapse/haproxy.rb
+++ b/lib/synapse/haproxy.rb
@@ -966,10 +966,11 @@ module Synapse
         return []
       end
 
+      bo = watcher.haproxy['bind_options']
       stanza = [
         "\nfrontend #{watcher.name}",
         config.map {|c| "\t#{c}"},
-        "\tbind #{ watcher.haproxy['bind_address'] || @opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}",
+        "\tbind #{ watcher.haproxy['bind_address'] || @opts['bind_address'] || 'localhost'}:#{watcher.haproxy['port']}#{ bo.nil? ? '' : ' ' + bo}",
         "\tdefault_backend #{watcher.haproxy.fetch('backend_name', watcher.name)}"
       ]
     end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -39,6 +39,13 @@ describe Synapse::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_frontend_with_bind_options) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service4')
+    allow(mockWatcher).to receive(:haproxy).and_return('port' => 2200, 'bind_options' => 'ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305')
+    mockWatcher
+  end
+
   let(:mockwatcher_frontend_with_bind_address) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service5')
@@ -279,6 +286,11 @@ describe Synapse::Haproxy do
   it 'generates frontend stanza ' do
     mockConfig = []
     expect(subject.generate_frontend_stanza(mockwatcher_frontend, mockConfig)).to eql(["\nfrontend example_service4", [], "\tbind localhost:2200", "\tdefault_backend example_service4"])
+  end
+
+  it 'generates frontend stanza with bind options ' do
+    mockConfig = []
+    expect(subject.generate_frontend_stanza(mockwatcher_frontend_with_bind_options, mockConfig)).to eql(["\nfrontend example_service4", [], "\tbind localhost:2200 ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305", "\tdefault_backend example_service4"])
   end
 
   it 'respects frontend bind_address ' do


### PR DESCRIPTION
This PR adds an additional parameter to support the ssl configuration in haproxy. As specified in test and example config, those options could be: {ssl, crt, ciphers, accept-proxy, ca-file etc.} 