### PR TITLE
Add Missing Quotation Mark in the Sample Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ For example:
     server_options: "check inter 2s rise 3 fall 2"
     shared_frontend:
      - "acl is_service1 hdr_dom(host) -i service2.lb.example.com"
-     - "use_backend service2 if is_service2
+     - "use_backend service2 if is_service2"
     backend:
      - "mode http"
 


### PR DESCRIPTION
* The sample configuration file provided under the section `HAProxy shared HTTP Frontend` is not a valid YAML file because of a missing quotation mark. This patch adds the missing quotation mark so that the configuration is usable as it is.