### PR TITLE
Add support for relative port overrides to the ec2 watcher.

### DIFF
--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -41,7 +41,7 @@ class Synapse::ServiceWatcher
           "Missing server_port_override for service #{@name} - which port are backends listening on?"
       end
 
-      unless @haproxy['server_port_override'].to_s.match(/^\d+$/)
+      unless @haproxy['server_port_override'].to_s.match(/^[-+]?\d+$/)
         raise ArgumentError, "Invalid server_port_override value"
       end
 

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -109,6 +109,19 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
       end
     end
 
+    context 'relative server_port override' do
+      it 'supports relative positive port' do
+          expect {
+            Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '+10'), mock_synapse)
+          }.not_to raise_error
+      end
+      it 'supports relative negative port' do
+          expect {
+            Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '-10'), mock_synapse)
+          }.not_to raise_error
+      end
+    end
+
     context 'invalid data' do
       it 'complains if the haproxy server_port_override is not a number' do
           expect {


### PR DESCRIPTION
haproxy supports relative port addresses, prefixed by a "+" or "-".
If this is set the server port is determined by adding the value to
the client's port.