### PR TITLE
Adds Docker watcher ability to use images without tags

### DIFF
--- a/lib/synapse/service_watcher/docker.rb
+++ b/lib/synapse/service_watcher/docker.rb
@@ -76,7 +76,7 @@ class Synapse::ServiceWatcher
         end
         # Discover containers that match the image/port we're interested in and have the port mapped to the host
         cnts = cnts.find_all do |cnt|
-          cnt["Image"].rpartition(":").first == @discovery["image_name"] \
+          cnt["Image"].split(":", 2).first == @discovery["image_name"] \
             and cnt["Ports"].has_key?(@discovery["container_port"].to_s()) \
             and cnt["Ports"][@discovery["container_port"].to_s()].length > 0
         end

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -122,5 +122,13 @@ describe Synapse::ServiceWatcher::DockerWatcher do
         expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
       end
     end
+
+    context 'finds images without tags' do
+      let(:docker_data) { [{"Ports" => "0.0.0.0:49153->6379/tcp, 0.0.0.0:49154->6390/tcp", "Image" => "mycool/image"}, {"Ports" => "0.0.0.0:49155->6379/tcp", "Image" => "wrong/image"}] }
+      it do
+        expect(Docker::Util).to receive(:parse_json).and_return(docker_data)
+        expect(subject.send(:containers)).to eql([{"name"=>"mainserver", "host"=>"server1.local", "port"=>"49153"}])
+      end
+    end
   end
 end


### PR DESCRIPTION
Really useful for local dev where an image might not have a tag yet.

The fix here was to use `split` instead of `rpartition` because `rpartition` has some unexpected behavior when there is no match.

```
"foo:bar".rpartition(":")    # ["foo", ":", "bar"]

"foo".rpartition(":")        # ["", "", "foo"]
```