### PR TITLE
cache haproxy stanzas in generate_config

### DIFF
--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -837,6 +837,11 @@ class Synapse::ConfigGenerator
       # a place to store the parsed haproxy config from each watcher
       @watcher_configs = {}
 
+      # a place to store generated frontend and backend stanzas
+      @frontends_cache = {}
+      @backends_cache = {}
+      @watcher_revisions = {}
+
       @state_file_path = @opts['state_file_path']
       @state_file_ttl = @opts.fetch('state_file_ttl', DEFAULT_STATE_FILE_TTL).to_i
     end
@@ -893,9 +898,6 @@ class Synapse::ConfigGenerator
       new_config = generate_base_config
       shared_frontend_lines = generate_shared_frontend
 
-      @frontends_cache ||= {}
-      @backends_cache ||= {}
-      @watcher_revisions ||= {}
       watchers.each do |watcher|
         watcher_config = watcher.config_for_generator[name]
         @watcher_configs[watcher.name] ||= parse_watcher_config(watcher)

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -6,7 +6,6 @@ class Synapse::ServiceWatcher
     include Synapse::Logging
 
     LEADER_WARN_INTERVAL = 30
-    MAX_REVISION = 99999999999
 
     attr_reader :name, :config_for_generator, :revision
 
@@ -202,7 +201,6 @@ class Synapse::ServiceWatcher
     # can be overridden in subclasses.
     def reconfigure!
       @revision += 1
-      @revision = 0 if @revision >= MAX_REVISION
       @synapse.reconfigure!
     end
   end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -6,13 +6,15 @@ class Synapse::ServiceWatcher
     include Synapse::Logging
 
     LEADER_WARN_INTERVAL = 30
+    MAX_REVISION = 99999999999
 
-    attr_reader :name, :config_for_generator
+    attr_reader :name, :config_for_generator, :revision
 
     def initialize(opts={}, synapse)
       super()
 
       @synapse = synapse
+      @revision = 0
 
       # set required service parameters
       %w{name discovery}.each do |req|
@@ -199,6 +201,8 @@ class Synapse::ServiceWatcher
     # Subclasses should not invoke this directly; it's only exposed so that it
     # can be overridden in subclasses.
     def reconfigure!
+      @revision += 1
+      @revision = 0 if @revision >= MAX_REVISION
       @synapse.reconfigure!
     end
   end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -14,6 +14,7 @@ describe Synapse::ConfigGenerator::Haproxy do
     allow(mockWatcher).to receive(:config_for_generator).and_return({
       'haproxy' => {'server_options' => "check inter 2000 rise 3 fall 2"}
     })
+    allow(mockWatcher).to receive(:revision).and_return(1)
     mockWatcher
   end
 
@@ -86,6 +87,7 @@ describe Synapse::ConfigGenerator::Haproxy do
     allow(mockWatcher).to receive(:config_for_generator).and_return({
       'haproxy' => {'port' => 2200, 'disabled' => true}
     })
+    allow(mockWatcher).to receive(:revision).and_return(1)
     mockWatcher
   end
 


### PR DESCRIPTION
Two things here.

First, we toggle ```updated``` on a service watcher from its ```set_backends``` method if we detect a diff in backends.

Second, in haproxy generator, in ```generate_config``` method we use cached frontend and backend stanzas unless a given watcher has ```updated``` set to true.

cc @jolynch