### PR TITLE
Do less work on file output updates

### DIFF
--- a/lib/synapse/config_generator/README.md
+++ b/lib/synapse/config_generator/README.md
@@ -7,6 +7,15 @@ when your generator has received an update from synapse via `update_config` it
 should sync the watcher state with the external configuration (e.g. HAProxy
 state)
 
+Note that you have access to the following **read only** methods on the
+watchers:
+
+* `config_for_generator[name]` -> Hash: A method for retrieving the watcher config
+ relevant to this particular config watcher.
+* `revision` -> int: A logical, monotonically increasing clock indicating which
+  revision of the watcher this is. You can use this to ignore config updates
+  from watchers that haven't changed
+
 ```ruby
 require "synapse/config_generator/base"
 

--- a/spec/lib/synapse/file_output_spec.rb
+++ b/spec/lib/synapse/file_output_spec.rb
@@ -18,6 +18,10 @@ describe Synapse::ConfigGenerator::FileOutput do
     allow(mockWatcher).to receive(:name).and_return('example_service')
     backends = [{ 'host' => 'somehost', 'port' => 5555}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return(
+      {'file_output' => {}}
+    )
+    allow(mockWatcher).to receive(:revision).and_return(0)
     mockWatcher
   end
   let(:mockwatcher_2) do
@@ -25,11 +29,21 @@ describe Synapse::ConfigGenerator::FileOutput do
     allow(mockWatcher).to receive(:name).and_return('foobar_service')
     backends = [{ 'host' => 'somehost', 'port' => 1234}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return(
+      {'file_output' => {}}
+    )
+    allow(mockWatcher).to receive(:revision).and_return(0)
     mockWatcher
   end
 
   it 'updates the config' do
     expect(subject).to receive(:write_backends_to_file)
+    subject.update_config([mockwatcher_1])
+  end
+
+  it 'ignores repeat configs' do
+    expect(subject).to receive(:write_backends_to_file).once
+    subject.update_config([mockwatcher_1])
     subject.update_config([mockwatcher_1])
   end
 


### PR DESCRIPTION
This uses the revision machinery to not have to JSON.load all the files every update.