### PR TITLE
Allow disabled files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.14.4)
+    synapse (0.14.5)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       logging (~> 1.8)

--- a/lib/synapse/config_generator/file_output.rb
+++ b/lib/synapse/config_generator/file_output.rb
@@ -68,7 +68,8 @@ class Synapse::ConfigGenerator
       # Cleanup old services that Synapse no longer manages
       FileUtils.cd(opts['output_directory']) do
         present_files = Dir.glob('*.json')
-        managed_files = current_watchers.collect {|watcher| "#{watcher.name}.json"}
+        managed_watchers = current_watchers.reject {|watcher| watcher.config_for_generator[name]['disabled']}
+        managed_files = managed_watchers.collect {|watcher| "#{watcher.name}.json"}
         files_to_purge = present_files.select {|svc| not managed_files.include?(svc)}
         log.info "synapse: purging unknown service files #{files_to_purge}" if files_to_purge.length > 0
         FileUtils.rm(files_to_purge)

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.14.4"
+  VERSION = "0.14.5"
 end

--- a/spec/lib/synapse/file_output_spec.rb
+++ b/spec/lib/synapse/file_output_spec.rb
@@ -36,6 +36,18 @@ describe Synapse::ConfigGenerator::FileOutput do
     mockWatcher
   end
 
+  let(:mockwatcher_disabled) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('disabled_service')
+    backends = [{ 'host' => 'somehost', 'port' => 1234}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return(
+      {'file_output' => {'disabled' => true}}
+    )
+    allow(mockWatcher).to receive(:revision).and_return(0)
+    mockWatcher
+  end
+
   it 'updates the config' do
     expect(subject).to receive(:write_backends_to_file)
     subject.update_config([mockwatcher_1])
@@ -48,13 +60,14 @@ describe Synapse::ConfigGenerator::FileOutput do
   end
 
   it 'manages correct files' do
-    subject.update_config([mockwatcher_1, mockwatcher_2])
+    subject.update_config([mockwatcher_1, mockwatcher_2, mockwatcher_disabled])
     FileUtils.cd(config['file_output']['output_directory']) do
       expect(Dir.glob('*.json').sort).to eql(['example_service.json', 'foobar_service.json'])
     end
     # Should clean up after itself
-    subject.update_config([mockwatcher_1])
     FileUtils.cd(config['file_output']['output_directory']) do
+      FileUtils.touch('disabled_service.json')
+      subject.update_config([mockwatcher_1, mockwatcher_disabled])
       expect(Dir.glob('*.json')).to eql(['example_service.json'])
     end
     # Should clean up after itself
@@ -67,7 +80,7 @@ describe Synapse::ConfigGenerator::FileOutput do
   it 'writes correct content' do
     subject.update_config([mockwatcher_1])
     data_path = File.join(config['file_output']['output_directory'],
-                          "example_service.json")
+                          'example_service.json')
     old_backends = JSON.load(File.read(data_path))
     expect(old_backends.length).to eql(1)
     expect(old_backends.first['host']).to eql('somehost')


### PR DESCRIPTION
@solarkennedy I think this should allow us to prevent the nginx_listeners from showing up in files (I have to disable in synapse-tools, but machinery is there now).