### PR TITLE
Make shuffle reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
   Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza.
   `desc` means descending alphabetical order.
   `no_shuffle` means no shuffling or sorting.
-  If you shuffle consider setting `seed` at the top level so that your backend
-  ordering is deterministic across HAProxy reloads
+  If you shuffle consider setting `server_order_seed` at the top level so that your backend
+  ordering is deterministic across HAProxy reloads.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
 * `cookie_value_method`: optional: default value is `name`, it defines the way your backends receive a cookie value in http mode. If equal to `hash`, synapse hashes backend names on cookie value assignation of your discovered backends, useful when you want to use haproxy cookie feature but you do not want that your end users receive a Set-Cookie with your server name and ip readable in clear.
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,12 @@ listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
 * `backend_name`: The name of the generated HAProxy backend for this service
   (defaults to the service's key in the `services` section)
 * `listen`: these lines will be parsed and placed in the correct `frontend`/`backend` section as applicable; you can put lines which are the same for the frontend and backend here.
-* `backend_order`: optional: how backends should be ordered in the `backend` stanza. (default is shuffling). Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza. `desc` means descending alphabetical order. `no_shuffle` means no shuffling or sorting.
+* `backend_order`: optional: how backends should be ordered in the `backend` stanza. (default is shuffling).
+  Setting to `asc` means sorting backends in ascending alphabetical order before generating stanza.
+  `desc` means descending alphabetical order.
+  `no_shuffle` means no shuffling or sorting.
+  If you shuffle consider setting `seed` at the top level so that your backend
+  ordering is deterministic across HAProxy reloads
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
 * `cookie_value_method`: optional: default value is `name`, it defines the way your backends receive a cookie value in http mode. If equal to `hash`, synapse hashes backend names on cookie value assignation of your discovered backends, useful when you want to use haproxy cookie feature but you do not want that your end users receive a Set-Cookie with your server name and ip readable in clear.
 
@@ -376,6 +381,12 @@ The top level `haproxy` section of the config file has the following options:
 * `state_file_ttl`: the number of seconds that backends should be kept in the
   state file cache.  This only applies if `state_file_path` is provided.
   (default: 86400)
+* `seed`: A number to seed random actions with so that all orders are
+  deterministic. You can use this so that backend ordering is deterministic
+  but still shuffled, for example by setting this to the hash of your machine's
+  IP address you guarantee that HAProxy on different machines have different
+  orders, but within that machine you always choose the same order.
+  (default: ``rand(2000)``)
 
 Note that a non-default `bind_address` can be dangerous.
 If you configure an `address:port` combination that is already in use on the system, haproxy will fail to start.

--- a/README.md
+++ b/README.md
@@ -381,12 +381,19 @@ The top level `haproxy` section of the config file has the following options:
 * `state_file_ttl`: the number of seconds that backends should be kept in the
   state file cache.  This only applies if `state_file_path` is provided.
   (default: 86400)
-* `seed`: A number to seed random actions with so that all orders are
+* `server_order_seed`: A number to seed random actions with so that all orders are
   deterministic. You can use this so that backend ordering is deterministic
   but still shuffled, for example by setting this to the hash of your machine's
   IP address you guarantee that HAProxy on different machines have different
   orders, but within that machine you always choose the same order.
   (default: ``rand(2000)``)
+* `max_server_id`: Synapse will try to ensure that server lines are written out
+  with HAProxy "id"s that are unique and associated 1:1 with a service backend
+  (host + port + name). To ensure these are unique Synapse internally counts
+  up from 1 until `max_server_id`, so you can have no more than this number
+  of servers in a backend. If the default (65k) is not enough, make this higher
+  but be wary that HAProxy internally uses an int to store this id, so ...
+  your mileage may vary trying to make this higher. (default: 65535)
 
 Note that a non-default `bind_address` can be dangerous.
 If you configure an `address:port` combination that is already in use on the system, haproxy will fail to start.

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -844,6 +844,9 @@ class Synapse::ConfigGenerator
 
       @state_file_path = @opts['state_file_path']
       @state_file_ttl = @opts.fetch('state_file_ttl', DEFAULT_STATE_FILE_TTL).to_i
+
+      # For giving consistent orders, even if they are random
+      @seed = rand(2000)
     end
 
     def normalize_watcher_provided_config(service_watcher_name, service_watcher_config)
@@ -1071,7 +1074,7 @@ class Synapse::ConfigGenerator
       when 'no_shuffle'
         backends.keys
       else
-        backends.keys.shuffle
+        backends.keys.shuffle(random: Random.new(@seed))
       end
 
       stanza = [

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -846,7 +846,7 @@ class Synapse::ConfigGenerator
       @state_file_ttl = @opts.fetch('state_file_ttl', DEFAULT_STATE_FILE_TTL).to_i
 
       # For giving consistent orders, even if they are random
-      @seed = rand(2000)
+      @seed = @opts.fetch('seed', rand(2000))
     end
 
     def normalize_watcher_provided_config(service_watcher_name, service_watcher_config)

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -849,7 +849,7 @@ class Synapse::ConfigGenerator
       @state_file_ttl = @opts.fetch('state_file_ttl', DEFAULT_STATE_FILE_TTL).to_i
 
       # For giving consistent orders, even if they are random
-      @server_order_seed = @opts.fetch('server_order_seed', rand(2000)).hash.to_i
+      @server_order_seed = @opts.fetch('server_order_seed', rand(2000)).to_i
       @max_server_id = @opts.fetch('max_server_id', MAX_SERVER_ID).to_i
       # Map of backend names -> hash of HAProxy server names -> puids
       # (server->id aka "name") to their proxy unique id (server->puid aka "id")

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1151,7 +1151,7 @@ class Synapse::ConfigGenerator
       end
 
       max_existing_id = @id_server_map[watcher_name].keys()[-1] || 0
-      probe = max_existing_id % @max_server_id + 1
+      probe = (max_existing_id % @max_server_id) + 1
 
       while @id_server_map[watcher_name].include?(probe)
         probe = (probe % @max_server_id) + 1
@@ -1350,7 +1350,8 @@ class Synapse::ConfigGenerator
           data = {
             'timestamp' => timestamp,
           }
-          if @server_id_map[watcher.name].has_key?(backend_name)
+          server_id = @server_id_map[watcher.name][backend_name]
+          if server_id && server_id > 0 && server_id <= MAX_SERVER_ID
             data['haproxy_server_id'] = @server_id_map[watcher.name][backend_name].to_i
           end
 

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -367,7 +367,7 @@ describe Synapse::ConfigGenerator::Haproxy do
 
   it 'generates backend stanza' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
+    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", [], ["\tserver somehost:5555 somehost:5555 id 1 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
   end
 
   describe 'generate backend stanza in correct order' do
@@ -376,25 +376,25 @@ describe Synapse::ConfigGenerator::Haproxy do
         'asc' => [
           "\nbackend example_service",
           [],
-          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2"
+          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 id 1 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 id 3 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 id 2 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2"
           ]
         ],
         'desc' => [
           "\nbackend example_service",
           [],
-          ["\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2"
+          ["\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 id 2 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 id 3 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 id 1 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2"
           ]
         ],
         'no_shuffle' => [
           "\nbackend example_service",
           [],
-          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2"
+          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 id 1 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 id 2 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 id 3 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2"
           ]
         ]
       }
@@ -444,17 +444,17 @@ describe Synapse::ConfigGenerator::Haproxy do
 
   it 'hashes backend name as cookie value' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_value_method_hash, mockConfig)).to eql(["\nbackend example_service3", [], ["\tserver somehost:5555 somehost:5555 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
+    expect(subject.generate_backend_stanza(mockwatcher_with_cookie_value_method_hash, mockConfig)).to eql(["\nbackend example_service3", [], ["\tserver somehost:5555 somehost:5555 id 1 cookie 9e736eef2f5a1d441e34ade3d2a8eb1e3abb1c92 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'generates backend stanza without cookies for tcp mode' do
     mockConfig = ['mode tcp']
-    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", ["\tmode tcp"], ["\tserver somehost:5555 somehost:5555 check inter 2000 rise 3 fall 2"]])
+    expect(subject.generate_backend_stanza(mockwatcher, mockConfig)).to eql(["\nbackend example_service", ["\tmode tcp"], ["\tserver somehost:5555 somehost:5555 id 1 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'respects haproxy_server_options' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
+    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 id 1 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
   end
 
   it 'generates frontend stanza ' do

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -373,6 +373,14 @@ describe Synapse::ConfigGenerator::Haproxy do
   describe 'generate backend stanza in correct order' do
     let(:multiple_backends_stanza_map) do
       {
+        'shuffle' => [
+          "\nbackend example_service",
+          [],
+          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
+           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
+          ]
+        ],
         'asc' => [
           "\nbackend example_service",
           [],
@@ -410,7 +418,7 @@ describe Synapse::ConfigGenerator::Haproxy do
       mockWatcher
     end
 
-    ['asc', 'desc', 'no_shuffle'].each do |order_option|
+    ['asc', 'desc', 'no_shuffle', 'shuffle'].each do |order_option|
       context "when #{order_option} is specified for backend_order" do
         it 'generates backend stanza in correct order' do
           mockConfig = []

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -21,7 +21,18 @@ describe Synapse::ConfigGenerator::Haproxy do
   let(:mockwatcher_with_server_options) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service2')
-    backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_options' => 'backup'}]
+    backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_options' => 'id 12 backup'}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'haproxy' => {'server_options' => "check inter 2000 rise 3 fall 2"}
+    })
+    mockWatcher
+  end
+
+  let(:mockwatcher_with_server_id) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service2')
+    backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_id' => '1337'}]
     allow(mockWatcher).to receive(:backends).and_return(backends)
     allow(mockWatcher).to receive(:config_for_generator).and_return({
       'haproxy' => {'server_options' => "check inter 2000 rise 3 fall 2"}
@@ -454,7 +465,12 @@ describe Synapse::ConfigGenerator::Haproxy do
 
   it 'respects haproxy_server_options' do
     mockConfig = []
-    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 id 1 cookie somehost:5555 check inter 2000 rise 3 fall 2 backup"]])
+    expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 id 12 backup"]])
+  end
+
+  it 'respects haproxy_server_id' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher_with_server_id, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 id 1337 cookie somehost:5555 check inter 2000 rise 3 fall 2"]])
   end
 
   it 'generates frontend stanza ' do

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -373,14 +373,6 @@ describe Synapse::ConfigGenerator::Haproxy do
   describe 'generate backend stanza in correct order' do
     let(:multiple_backends_stanza_map) do
       {
-        'shuffle' => [
-          "\nbackend example_service",
-          [],
-          ["\tserver somehost1_10.11.11.11:5555 10.11.11.11:5555 cookie somehost1_10.11.11.11:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost3_10.22.22.22:5555 10.22.22.22:5555 cookie somehost3_10.22.22.22:5555 check inter 2000 rise 3 fall 2",
-           "\tserver somehost2_10.10.10.10:5555 10.10.10.10:5555 cookie somehost2_10.10.10.10:5555 check inter 2000 rise 3 fall 2",
-          ]
-        ],
         'asc' => [
           "\nbackend example_service",
           [],
@@ -418,7 +410,7 @@ describe Synapse::ConfigGenerator::Haproxy do
       mockWatcher
     end
 
-    ['asc', 'desc', 'no_shuffle', 'shuffle'].each do |order_option|
+    ['asc', 'desc', 'no_shuffle'].each do |order_option|
       context "when #{order_option} is specified for backend_order" do
         it 'generates backend stanza in correct order' do
           mockConfig = []
@@ -430,6 +422,22 @@ describe Synapse::ConfigGenerator::Haproxy do
           })
           expect(subject.generate_backend_stanza(mockwatcher_with_multiple_backends, mockConfig)).to eql(multiple_backends_stanza_map[order_option])
         end
+      end
+    end
+
+    context "when shuffle is specified for backend_order" do
+      it 'generates backend stanza in reproducible order' do
+        mockConfig = []
+        allow(mockwatcher_with_multiple_backends).to receive(:config_for_generator).and_return({
+          'haproxy' => {
+            'server_options' => "check inter 2000 rise 3 fall 2",
+            'backend_order' => 'shuffle',
+            'seed' => 1234,
+          }
+        })
+        runs = (1..5).collect { |_| subject.generate_backend_stanza(mockwatcher_with_multiple_backends, mockConfig) }
+        expect(runs.length).to eq(5)
+        expect(runs.uniq.length).to eq(1)
       end
     end
   end

--- a/spec/support/minimum.conf.yaml
+++ b/spec/support/minimum.conf.yaml
@@ -27,7 +27,6 @@ haproxy:
     - global_test_option
   defaults:
     - default_test_option
-  seed: 1234
 
 # settings for the file output generator
 file_output:

--- a/spec/support/minimum.conf.yaml
+++ b/spec/support/minimum.conf.yaml
@@ -25,10 +25,9 @@ haproxy:
   do_socket: false
   global:
     - global_test_option
-
   defaults:
     - default_test_option
-
+  seed: 1234
 
 # settings for the file output generator
 file_output:


### PR DESCRIPTION
This way we still get different orders on different client machines,
preventing long lived connections from all hitting the first or second
server, but also for reloads we get a consistent ordering that does not
invalidate the HAProxy state file (which assumes your backends don't
change order).