### PR TITLE
To find the next server id, just count up

### DIFF
--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1150,8 +1150,7 @@ class Synapse::ConfigGenerator
         return probe
       end
 
-      max_existing_id = @id_server_map[watcher_name].keys.compact.max || 0
-      probe = (max_existing_id % @max_server_id) + 1
+      probe = 1
 
       while @id_server_map[watcher_name].include?(probe)
         probe = (probe % @max_server_id) + 1


### PR DESCRIPTION
The .max was already a linear scan ... I feel like this is just easier to reason about (less likely to have strange bugs where we wrap around and something doesn't go to plan).