### PR TITLE
[synapse] fix bug in generate_backend_stanze

### DIFF
--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1068,7 +1068,7 @@ class Synapse::ConfigGenerator
 
       # The ordering here is important.  First we add all the backends in the
       # disabled state...
-      @state_cache.backends(watcher).each do |backend_name, backend|
+      @state_cache.backends(watcher.name).each do |backend_name, backend|
         backends[backend_name] = backend.merge('enabled' => false)
         # We remember the haproxy_server_id from a previous reload here.
         # Note though that if live servers below define haproxy_server_id


### PR DESCRIPTION
to: @jolynch 

## what
A bug was introduced into the generate_Backend_stanza. @state_cache.backends is expecting watcher.name as the input argument, but it got the watcher object.
With the bug, when Synapse generates the haproxy config, it only sees the "enabled" services as reported by the watchers, but does not see all known backends in the state cache (because search by 'watch', instead of watcher.name, in the state cache failed silently). This increases number of haproxy restarts when Synapse is restarted. 

## fix
Pass the correct argument to @state_cache.backends

## test
Added rspec test to cover this bug.