### PR TITLE
Support embedded ruby (ERB) in config files

### DIFF
--- a/bin/synapse
+++ b/bin/synapse
@@ -2,6 +2,7 @@
 
 require 'yaml'
 require 'optparse'
+require 'erb'
 
 require 'synapse'
 
@@ -32,13 +33,18 @@ optparse.parse!
 def parseconfig(filename)
   # parse synapse config file
   begin
-    c = YAML::parse(File.read(filename))
+    c = YAML::parse(ERB.new(File.read(filename)).result)
   rescue Errno::ENOENT => e
     raise ArgumentError, "config file does not exist:\n#{e.inspect}"
   rescue Errno::EACCES => e
     raise ArgumentError, "could not open config file:\n#{e.inspect}"
   rescue YAML::SyntaxError => e
     raise "config file #{filename} is not yaml:\n#{e.inspect}"
+  rescue SyntaxError => e
+    raise SyntaxError, "ERB syntax error in config file #{filename}:\n#{e.inspect}"
+  rescue
+    puts "failed to parse config file #{filename}"
+    raise
   end
   return c.to_ruby
 end

--- a/spec/bin/synapse_spec.rb
+++ b/spec/bin/synapse_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+require 'tempfile'
+
+describe 'parseconfig' do
+  it 'parses a templated config' do
+    allow_any_instance_of(Synapse::Synapse).to receive(:run)
+    expect(Synapse::Synapse).to receive(:new).
+      with(hash_including(
+       {"services" =>
+          {"test" =>
+            {"default_servers" =>
+              [{"name" => "default1", "host" => "localhost", "port" => 8080}],
+             "discovery" =>
+              {"method" => "zookeeper",
+               "path" => "/airbnb/service/logging/event_collector",
+               "hosts" => ["localhost:2181"],
+               "label_filters" =>
+                [{"label" => "tag", "value" => "config value", "condition" => "equals"}]},
+             "haproxy" =>
+              {"port" => 3219,
+               "bind_address" => "localhost",
+               "server_options" => ["some_haproxy_server_option"],
+               "listen" => ["some_haproxy_listen_option"]}}},
+         "haproxy" =>
+          {"reload_command" => "sudo service haproxy reload",
+           "config_file_path" => "/etc/haproxy/haproxy.cfg",
+           "do_writes" => false,
+           "do_reloads" => false,
+           "do_socket" => false,
+           "global" => ["global_test_option"],
+           "defaults" => ["default_test_option"]},
+         "file_output" => {"output_directory" => "/tmp/synapse_file_output_test"}}
+      )).and_call_original
+    stub_const 'ENV', ENV.to_hash.merge(
+      {"SYNAPSE_CONFIG" => "#{File.dirname(__FILE__)}/../support/minimum.conf.yaml",
+      "SYNAPSE_CONFIG_VALUE" => "config value"}
+    )
+    stub_const 'ARGV', []
+    load "#{File.dirname(__FILE__)}/../../bin/synapse"
+  end
+
+  it 'fails if templated config is invalid' do
+    allow_any_instance_of(Synapse::Synapse).to receive(:run)
+    tmpcfg = Tempfile.new 'synapse.conf.yaml'
+    tmpcfg.write '{:a => "<% if %>"}'
+    tmpcfg.flush
+    stub_const 'ENV', ENV.to_hash.merge(
+      {"SYNAPSE_CONFIG" => tmpcfg.to_path,
+      "SYNAPSE_CONFIG_VALUE" => "config value"}
+    )
+    stub_const 'ARGV', []
+    expect {
+      load "#{File.dirname(__FILE__)}/../../bin/synapse"
+    }.to raise_error(SyntaxError)
+  end
+end

--- a/spec/support/configuration.rb
+++ b/spec/support/configuration.rb
@@ -1,7 +1,9 @@
 require "yaml"
+require "erb"
 
 module Configuration
   def config
-    @config ||= YAML::load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'minimum.conf.yaml'))
+    filename = File.join(File.dirname(File.expand_path(__FILE__)), 'minimum.conf.yaml')
+    @config ||= YAML::load(ERB.new(File.read(filename)).result)
   end
 end

--- a/spec/support/minimum.conf.yaml
+++ b/spec/support/minimum.conf.yaml
@@ -8,6 +8,8 @@ services:
       path: /airbnb/service/logging/event_collector
       hosts:
         - localhost:2181
+      label_filters:
+        - { label: "tag", value: "<%= ENV['SYNAPSE_CONFIG_VALUE'] %>", condition: "equals" }
     haproxy:
       port: 3219
       bind_address: 'localhost'


### PR DESCRIPTION
Allows for string interpolation and other Ruby syntax in config files. Useful to dynamically build services based on local environment.