### PR TITLE
add generator_config_path config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ It takes the following mandatory arguments:
 
 The watcher assumes that each node under `path` represents a service server.
 
-The watcher assumes that the data (if any) retrieved at znode `path` is a hash, where each key is named by a valid `config_generator` (e.g. `haproxy`) and the value is a hash that configs the generator.
+The watcher assumes that the data (if any) retrieved at znode `path` is a hash, where each key is named by a valid `config_generator` (e.g. `haproxy`) and the value is a hash that configs the generator.   Alternatively, if a `generator_config_path` argument is specified, the watcher will attempt to read generator config from that znode instead.
+If `generator_config_path` has the value `disabled`, then generator config will not be read from zookeeper at all.
 
 The following arguments are optional:
 


### PR DESCRIPTION
## Summary

This PR adds a `generator_config_path` option that can be used to determine where the zookeeper discovery method will look in zookeeper for the generator config.    This PR also adds a "disabled" option to prevent generator configs from being read from zookeeper.

Prior to this patch, the `path` option is used, and if the `path` node in zookeeper has data, that data always overrides any other generator config.

However, there are cases where you want to have multiple generator configs that share the same instances; for example, for az-aware routing.      In order to safely roll out this feature, you may also swant to disable the zookeeper-based loading of generator config information.

### Example:

For az-aware routing, you might implement this with two smartstack services, as follows:

```
  "services": {
    "sampleapp": {
      "discovery": {
        "method": "zookeeper",
        "path": "/production/services/sampleapp/services"
      },
      "haproxy": {
        "port": 11001,
        "server_options": "check inter 10s rise 8 fall 9",
        "frontend": [
          "acl use_local_backend nbsrv(sampleapp-local-az) ge 1",
          "use_backend sampleapp-local-az if use_local_backend",
          "bind ::1:11001"
        ],
        "listen": [
          "mode http",
          "option httpchk GET /health",
          "cookie SRVID insert indirect nocache",
          "option httplog"
        ]
      }
    },
    "sampleapp-local-az": {
      "discovery": {
        "label_filter": {
          "condition": "equals",
          "label": "az",
          "value": "us-east-1b"
        },
        "method": "zookeeper",
        "path": "/production/services/sampleapp/services"
      },
      "haproxy": {
        "server_options": "check inter 10s rise 8 fall 9",
        "frontend": [
          "acl use_local_backend nbsrv(sampleapp-local-az) ge 1",
          "use_backend sampleapp-local-az if use_local_backend",
          "bind ::1:11001"
        ],
        "listen": [
          "mode http",
          "option httpchk GET /health",
          "cookie SRVID insert indirect nocache",
          "option httplog"
        ]
      }
    }
  }
```

In this example, `sampleapp` and `sampleap-local-az` share the same path for instance discovery in zookeeper, but require different generator configs (different `haproxy` sections).     This isn't possible to express with the current zookeeper-based generator config discovery.     With this PR, this can be done as:

```
  "services": {
    "sampleapp": {
      "discovery": {
        "method": "zookeeper",
        "path": "/production/services/sampleapp/services",
        "generator_config_path": "/production/services/sampleapp/services"
      }
    },
    "sampleapp-local-az": {
      "discovery": {
        "label_filter": {
          "condition": "equals",
          "label": "az",
          "value": "us-east-1b"
        },
        "method": "zookeeper",
        "path": "/production/services/sampleapp/services",
        "generator_config_path": "/production/services/sampleapp-local-az/services"
      }
    }
  }
```
