### PR TITLE
[Synapse] fix synapse panic in short disconnection

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -47,7 +47,9 @@ class Synapse::ServiceWatcher
     def ping?
       # @zk being nil implies no session *or* a lost session, do not remove
       # the check on @zk being truthy
-      @zk && @zk.connected?
+      # if the client is in any of the three states: associating, connecting, connected
+      # we consider it alive. this can avoid synapse restart on short network dis-connection
+      @zk && (@zk.associating? || @zk.connecting? || @zk.connected?)
     end
 
     private

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -125,6 +125,15 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       subject.send(:watcher_callback).call
     end
 
+    it 'responds fail to ping? when the client is not in any of the connected/connecting/associatin state' do
+      expect(mock_zk).to receive(:associating?).and_return(false)
+      expect(mock_zk).to receive(:connecting?).and_return(false)
+      expect(mock_zk).to receive(:connected?).and_return(false)
+
+      subject.instance_variable_set('@zk', mock_zk)
+      expect(subject.ping?).to be false
+    end
+    
     context "when generator_config_path is defined" do
       let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => 'some/other/path' } }
 


### PR DESCRIPTION
Summary

This PR makes synapse watcher to keep alive as long as the session has not expired. The change avoids unnecessary Synapse restart when there is only short network disconnection between watcher and the zk cluster.

Reviewers
@darnaut @alexism 
