### PR TITLE
Adding `statsd` dependency and exporting some stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    synapse (0.15.1)
+    synapse (0.15.2)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
+      dogstatsd-ruby (~> 3.3.0)
       hashdiff (~> 0.2.3)
       logging (~> 1.8)
       zk (~> 1.9.4)
@@ -18,35 +19,38 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    aws-sdk (1.66.0)
-      aws-sdk-v1 (= 1.66.0)
-    aws-sdk-v1 (1.66.0)
+    aws-sdk (1.67.0)
+      aws-sdk-v1 (= 1.67.0)
+    aws-sdk-v1 (1.67.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4)
+      nokogiri (~> 1)
     coderay (1.1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    docker-api (1.29.0)
-      excon (>= 0.38.0)
-      json
-    excon (0.49.0)
+    docker-api (1.34.2)
+      excon (>= 0.47.0)
+      multi_json
+    dogstatsd-ruby (3.3.0)
+    excon (0.61.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
     ffi (1.9.10-java)
     hashdiff (0.2.3)
     i18n (0.7.0)
     json (1.8.3)
-    little-plugger (1.1.3)
+    json (1.8.3-java)
+    little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
     method_source (0.8.2)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.9.0)
-    multi_json (1.11.2)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    multi_json (1.13.1)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    nokogiri (1.6.8.1-java)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -73,9 +77,12 @@ GEM
     rspec-support (3.1.2)
     safe_yaml (1.0.4)
     slop (3.6.0)
+    slyphon-log4j (1.2.15)
+    slyphon-zookeeper_jar (3.3.5-java)
     spoon (0.0.4)
       ffi
     thread_safe (0.3.5)
+    thread_safe (0.3.5-java)
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -86,6 +93,9 @@ GEM
     zk (1.9.6)
       zookeeper (~> 1.4.0)
     zookeeper (1.4.11)
+    zookeeper (1.4.11-java)
+      slyphon-log4j (= 1.2.15)
+      slyphon-zookeeper_jar (= 3.3.5)
 
 PLATFORMS
   java
@@ -102,4 +112,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/config/synapse.conf.json
+++ b/config/synapse.conf.json
@@ -1,4 +1,8 @@
 {
+  "statsd": {
+    "host": "localhost",
+    "port": 8125
+  },
   "services": {
     "service1": {
       "default_servers": [

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -3,6 +3,7 @@ require 'json'
 
 require 'synapse/version'
 require 'synapse/log'
+require 'synapse/statsd'
 require 'synapse/config_generator'
 require 'synapse/service_watcher'
 
@@ -11,8 +12,11 @@ module Synapse
   class Synapse
 
     include Logging
+    include StatsD
 
     def initialize(opts={})
+      StatsD.configure_statsd(opts["statsd"] || {})
+
       # create objects that need to be notified of service changes
       @config_generators = create_config_generators(opts)
       raise "no config generators supplied" if @config_generators.empty?
@@ -29,47 +33,76 @@ module Synapse
       Thread.abort_on_exception = true
 
       log.debug "synapse: completed init"
+    rescue Exception => e
+      statsd && statsd.increment('synapse.stop', tags: ['stop_avenue:abort', 'stop_location:init'])
+      raise e
     end
 
     # start all the watchers and enable haproxy configuration
     def run
       log.info "synapse: starting..."
+      statsd.increment('synapse.start')
 
       # start all the watchers
-      @service_watchers.map { |watcher| watcher.start }
-
-      # main loop
-      loops = 0
-      loop do
-        @service_watchers.each do |w|
-          raise "synapse: service watcher #{w.name} failed ping!" unless w.ping?
-        end
-
-        if @config_updated
-          @config_updated = false
-          @config_generators.each do |config_generator|
-            log.info "synapse: configuring #{config_generator.name}"
-            config_generator.update_config(@service_watchers)
+      statsd.time('synapse.watchers.start.time') do
+        @service_watchers.map do |watcher|
+          begin
+            watcher.start
+            statsd.increment("synapse.watcher.start", tags: ['start_result:success', "watcher_name:#{watcher.name}"])
+          rescue Exception => e
+            statsd.increment("synapse.watcher.start", tags: ['start_result:fail', "watcher_name:#{watcher.name}"])
+            raise e
           end
         end
+      end
 
-        sleep 1
-        @config_generators.each do |config_generator|
-          config_generator.tick(@service_watchers)
+      statsd.time('synapse.main_loop.elapsed_time') do
+        # main loop
+        loops = 0
+        loop do
+          @service_watchers.each do |w|
+            alive = w.ping?
+            statsd.increment('synapse.watcher.ping.count', tags: ["watcher_name:#{w.name}", "ping_result:#{alive ? "success" : "failure"}"])
+            raise "synapse: service watcher #{w.name} failed ping!" unless alive
+          end
+
+          if @config_updated
+            @config_updated = false
+            statsd.increment('synapse.config.update')
+            @config_generators.each do |config_generator|
+              log.info "synapse: configuring #{config_generator.name}"
+              config_generator.update_config(@service_watchers)
+            end
+          end
+
+          sleep 1
+          @config_generators.each do |config_generator|
+            config_generator.tick(@service_watchers)
+          end
+
+          loops += 1
+          log.debug "synapse: still running at #{Time.now}" if (loops % 60) == 0
         end
-
-        loops += 1
-        log.debug "synapse: still running at #{Time.now}" if (loops % 60) == 0
       end
 
     rescue StandardError => e
+      statsd.increment('synapse.stop', tags: ['stop_avenue:abort', 'stop_location:main_loop'])
       log.error "synapse: encountered unexpected exception #{e.inspect} in main thread"
       raise e
     ensure
       log.warn "synapse: exiting; sending stop signal to all watchers"
 
       # stop all the watchers
-      @service_watchers.map(&:stop)
+      @service_watchers.map do |w|
+        begin
+          w.stop
+          statsd.increment("synapse.watcher.stop", tags: ['stop_avenue:clean', 'stop_location:main_loop', "watcher_name:#{w.name}"])
+        rescue Exception => e
+          statsd.increment("synapse.watcher.stop", tags: ['stop_avenue:exception', 'stop_location:main_loop', "watcher_name:#{w.name}"])
+          raise e
+        end
+      end
+      statsd.increment('synapse.stop', tags: ['stop_avenue:clean', 'stop_location:main_loop'])
     end
 
     def reconfigure!

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1287,7 +1287,7 @@ class Synapse::ConfigGenerator
         return false
       else
         tmp_file_path = "#{opts['config_file_path']}_#{Time.now.to_i}.tmp"
-        File.write(tmp_file_path, data)
+        File.write(tmp_file_path, new_config)
         FileUtils.mv(tmp_file_path, opts['config_file_path'])
         return true
       end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -1,10 +1,12 @@
 require 'synapse/log'
+require 'synapse/statsd'
 require 'set'
 require 'hashdiff'
 
 class Synapse::ServiceWatcher
   class BaseWatcher
     include Synapse::Logging
+    include Synapse::StatsD
 
     LEADER_WARN_INTERVAL = 30
 

--- a/lib/synapse/statsd.rb
+++ b/lib/synapse/statsd.rb
@@ -1,0 +1,28 @@
+require 'datadog/statsd'
+require 'synapse/log'
+
+module Synapse
+  module StatsD
+    def statsd
+      @@STATSD ||= StatsD.statsd_for(self.class.name)
+    end
+
+    class << self
+      include Logging
+
+      @@STATSD_HOST = "localhost"
+      @@STATSD_PORT = 8125
+
+      def statsd_for(classname)
+        log.debug "synapse: creating statsd client for class '#{classname}' on host '#{@@STATSD_HOST}' port #{@@STATSD_PORT}"
+        Datadog::Statsd.new(@@STATSD_HOST, @@STATSD_PORT)
+      end
+
+      def configure_statsd(opts)
+        @@STATSD_HOST = opts['host'] || @@STATSD_HOST
+        @@STATSD_PORT = (opts['port'] || @@STATSD_PORT).to_i
+        log.info "synapse: configuring statsd on host '#{@@STATSD_HOST}' port #{@@STATSD_PORT}"
+      end
+    end
+  end
+end

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.15.1"
+  VERSION = "0.15.2"
 end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -311,6 +311,13 @@ describe Synapse::ConfigGenerator::Haproxy do
         expect(subject).to receive(:write_config).with(new_config)
         subject.update_config(watchers)
       end
+
+      it 'writes the new config to the file system' do
+        expect(File).to receive(:read).and_return(nil)
+        expect(File).to receive(:write)
+        expect(FileUtils).to receive(:mv)
+        subject.update_config(watchers)
+      end
     end
 
     context 'if we do not support config writes' do

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "zk", "~> 1.9.4"
   gem.add_runtime_dependency "logging", "~> 1.8"
   gem.add_runtime_dependency "hashdiff", "~> 0.2.3"
+  gem.add_runtime_dependency "dogstatsd-ruby", "~> 3.3.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1.0"


### PR DESCRIPTION
Adding support for exporting metrics through `statsd`.
Also, exporting basic metrics about `synapse`'s health and performance.

How it was tested:
unit tests + manual run and checking exported metrics

Reviewers: @lap1817 @alexism 