### PR TITLE
Add weight support for haproxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
   ordering is deterministic across HAProxy reloads.
 * `shared_frontend`: optional: haproxy configuration directives for a shared http frontend (see below)
 * `cookie_value_method`: optional: default value is `name`, it defines the way your backends receive a cookie value in http mode. If equal to `hash`, synapse hashes backend names on cookie value assignation of your discovered backends, useful when you want to use haproxy cookie feature but you do not want that your end users receive a Set-Cookie with your server name and ip readable in clear.
+* `use_nerve_weights`: optional: this option enables reading the weights from nerve and applying them to the haproxy configuration. By default this is disabled in the case where users apply weights using `server_options` or `haproxy_server_options`.  This option will also remove the weight parameter from `server_options` and `haproxy_server_options`
 
 <a name="haproxy"/>
 

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1153,6 +1153,7 @@ class Synapse::ConfigGenerator
               b = "#{b} cookie #{backend_name}"
             end
           end
+          b = "#{b} weight #{backend['weight']}" if backend['weight']
           b = "#{b} #{watcher_config['server_options']}" if watcher_config['server_options'].is_a? String
           b = "#{b} #{backend['haproxy_server_options']}" if backend['haproxy_server_options'].is_a? String
           b = "#{b} disabled" unless backend['enabled']

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -107,6 +107,18 @@ describe Synapse::ConfigGenerator::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_with_weight) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_weighted_service')
+    backends = [{ 'host' => 'somehost', 'port' => 5555, 'weight' => 1}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'haproxy' => {
+      }
+    })
+    mockWatcher
+  end
+
   let(:mockwatcher_frontend) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('example_service4')
@@ -654,6 +666,13 @@ describe Synapse::ConfigGenerator::Haproxy do
         ]
       ]
     )
+  end
+
+  it 'respects backend weight' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher_with_weight, mockConfig)).to eql(
+      ["\nbackend example_weighted_service", [], ["\tserver somehost:5555 somehost:5555 id 1 cookie somehost:5555 weight 1"]]
+      )
   end
 
   it 'generates frontend stanza ' do


### PR DESCRIPTION
Create option for using nerve weights to be backwards compatible, it requires handling the use-case where users implemented HAProxy weighting using the `server_options` or `haproxy_server_options`.  This allows for users to enable the weight functionality with the option of `use_nerve_weights`

Added logic to remove the weight options from `server_options` and `haproxy_server_options` when `use_nerve_weights` is enabled.  This is to prevent producing an odd haproxy backend configuration with multiple weights.
