### PR TITLE
Allow DNS discovery to handle service nodes with an IP address for host

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.15.3)
+    synapse (0.15.4)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/dns.rb
+++ b/lib/synapse/service_watcher/dns.rb
@@ -59,10 +59,16 @@ class Synapse::ServiceWatcher
       end
     end
 
+    IP_REGEX = Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex])
+
     def resolve_servers
       resolver.tap do |dns|
         resolution = discovery_servers.map do |server|
-          addresses = dns.getaddresses(server['host']).map(&:to_s)
+          if server['host'] =~ IP_REGEX
+            addresses = [server['host']]
+          else
+            addresses = dns.getaddresses(server['host']).map(&:to_s)
+          end
           [server, addresses.sort]
         end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.15.3"
+  VERSION = "0.15.4"
 end

--- a/spec/lib/synapse/service_watcher_dns_spec.rb
+++ b/spec/lib/synapse/service_watcher_dns_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'synapse/service_watcher/dns'
+
+describe Synapse::ServiceWatcher::DnsWatcher do
+  let(:mock_synapse) do
+    mock_synapse = instance_double(Synapse::Synapse)
+    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
+    allow(mock_synapse).to receive(:available_generators).and_return({
+      'haproxy' => mockgenerator
+    })
+    mock_synapse
+  end
+
+  let(:discovery) do
+    {
+      'method' => 'dns',
+      'servers' => servers,
+      'generator_config_path' => 'disabled',
+    }
+  end
+
+  let(:config) do
+    {
+      'name' => 'test',
+      'haproxy' => {},
+      'discovery' => discovery,
+    }
+  end
+
+  let (:servers) do
+    [
+      {'name' => 'test1', 'host' => 'localhost'},
+      {'name' => 'test2', 'host' => '127.0.0.1'},
+      {'name' => 'test3', 'host' => '::1'},
+    ]
+  end
+
+  subject { Synapse::ServiceWatcher::DnsWatcher.new(config, mock_synapse) }
+
+  it 'only resolves hostnames' do
+    resolver = instance_double("Resolv::DNS")
+    allow(subject).to receive(:resolver).and_return(resolver)
+    expect(resolver).to receive(:getaddresses).with('localhost').
+      and_return([Resolv::IPv4.create('127.0.0.2')])
+    expect(subject.send(:resolve_servers)).to eql([
+      [{'name' => 'test1', 'host' => 'localhost'}, ['127.0.0.2']],
+      [{'name' => 'test2', 'host' => '127.0.0.1'}, ['127.0.0.1']],
+      [{'name' => 'test3', 'host' => '::1'}, ['::1']],
+    ])
+  end
+end


### PR DESCRIPTION
Allow the the `dns` and `zookeeper_dns` service discovery methods to handle service nodes with an IP address for the `host` field.

This facilities migrating services from other discovery methods (such as `zookeeper`) to the `dns` (or `zookeeper_dns`) method by allowing the service discovery method to be changed before publishing new service nodes with hostnames.