### PR TITLE
Support basic templating in server options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.15.4)
+    synapse (0.16.0)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ different addresses (example: service1 listen on 127.0.0.2:443 and service2
 listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
 * `bind_options`: optional: default value is an empty string, specify additional bind parameters, such as ssl accept-proxy, crt, ciphers etc.
 * `server_port_override`: **DEPRECATED**. Renamed [`backend_port_override`](#backend_port_override) and moved to the top level hash. This will be removed in future versions.
-* `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out.
+* `server_options`: the haproxy options for each `server` line of the service in HAProxy config; it may be left out. This field supports some basic templating: you can add include `%{port}`, `%{host}`, or `%{name}` in this string, and those will be replaced with the appropriate values for the particular server being configured.
 * `frontend`: additional lines passed to the HAProxy config in the `frontend` stanza of this service
 * `backend`: additional lines passed to the HAProxy config in the `backend` stanza of this service
 * `backend_name`: The name of the generated HAProxy backend for this service

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1141,6 +1141,11 @@ class Synapse::ConfigGenerator
         config.map {|c| "\t#{c}"},
         keys.map {|backend_name|
           backend = backends[backend_name]
+          backend_template_vars = {
+            :host => backend['host'],
+            :port => backend['port'],
+            :name => backend_name,
+          }
           b = "\tserver #{backend_name} #{backend['host']}:#{backend['port']}"
 
           # Again, if the registry defines an id, we can't set it.
@@ -1167,14 +1172,14 @@ class Synapse::ConfigGenerator
             if clean_haproxy_server_options != backend['haproxy_server_options']
                 log.warn "synapse: weight is defined in both haproxy_server_options and nerve. nerve weight will take precedence"
             end
-            b = "#{b} #{clean_server_options}" if clean_server_options
-            b = "#{b} #{clean_haproxy_server_options}" if clean_haproxy_server_options
+            b = "#{b} #{clean_server_options % backend_template_vars}" if clean_server_options
+            b = "#{b} #{clean_haproxy_server_options % backend_template_vars}" if clean_haproxy_server_options
 
             weight = backend['weight'].to_i
             b = "#{b} weight #{weight}".squeeze(" ")
           else
-            b = "#{b} #{watcher_config['server_options']}" if watcher_config['server_options'].is_a? String
-            b = "#{b} #{backend['haproxy_server_options']}" if backend['haproxy_server_options'].is_a? String
+            b = "#{b} #{watcher_config['server_options'] % backend_template_vars}" if watcher_config['server_options'].is_a? String
+            b = "#{b} #{backend['haproxy_server_options'] % backend_template_vars}" if backend['haproxy_server_options'].is_a? String
           end
           b = "#{b} disabled" unless backend['enabled']
           b }

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.15.4"
+  VERSION = "0.16.0"
 end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -212,6 +212,17 @@ describe Synapse::ConfigGenerator::Haproxy do
     mockWatcher
   end
 
+  let(:mockwatcher_with_server_option_templates) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service7')
+    backends = [{ 'host' => 'somehost', 'port' => 5555, 'haproxy_server_options' => 'id 12 backup'}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'haproxy' => {'server_options' => "check port %{port} inter 2000 rise 3 fall 2"}
+    })
+    mockWatcher
+  end
+
   describe '#initialize' do
     it 'succeeds on minimal config' do
       conf = {
@@ -717,6 +728,11 @@ describe Synapse::ConfigGenerator::Haproxy do
   it 'respects haproxy_server_options' do
     mockConfig = []
     expect(subject.generate_backend_stanza(mockwatcher_with_server_options, mockConfig)).to eql(["\nbackend example_service2", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check inter 2000 rise 3 fall 2 id 12 backup"]])
+  end
+
+  it 'templates haproxy backend options' do
+    mockConfig = []
+    expect(subject.generate_backend_stanza(mockwatcher_with_server_option_templates, mockConfig)).to eql(["\nbackend example_service7", [], ["\tserver somehost:5555 somehost:5555 cookie somehost:5555 check port 5555 inter 2000 rise 3 fall 2 id 12 backup"]])
   end
 
   it 'respects haproxy_server_id' do


### PR DESCRIPTION
Add support for some basic template interpolation in the `server_options` field. The name, host, and port of a particular backend server are made available for insertion into a `server_options` block, so that a server options configuration can be supplied to synapse that will vary based on the details of a host being configured. This allows options to be set that are dependent on information coming from the service discovery backend.

In particular, this allows one to disable TLS health checks for a TLS backend by specifying `check port <portnumber>`, where `portnumber` varies depending on the backend port that has been discovered by your discovery system.

@lap1817 @juchem @Jason-Jian 