### PR TITLE
Specify the EC2Provider if no keys are provided

### DIFF
--- a/lib/synapse/service_watcher/ec2tag.rb
+++ b/lib/synapse/service_watcher/ec2tag.rb
@@ -10,6 +10,11 @@ class Synapse::ServiceWatcher
       region = @discovery['aws_region'] || ENV['AWS_REGION']
       log.info "Connecting to EC2 region: #{region}"
 
+      unless ((@discovery['aws_access_key_id'] || ENV['aws_access_key_id']) \
+              && (@discovery['aws_secret_access_key'] || ENV['aws_secret_access_key'] ))
+        AWS.config(:credential_provider => AWS::Core::CredentialProviders::EC2Provider.new(:retries => 0))
+      end
+
       @ec2 = AWS::EC2.new(
         region:            region,
         access_key_id:     @discovery['aws_access_key_id']     || ENV['AWS_ACCESS_KEY_ID'],


### PR DESCRIPTION
If no keys are provided in @discovery / ENV, synapse is susceptible to entering an unrecoverable failure if it tries to get keys from metadata service when it is unavailable.