### PR TITLE
do not fail for no generator-config-path zk node

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -195,11 +195,11 @@ class Synapse::ServiceWatcher
               @zk.get(@discovery[discovery_key], :watch => true)
             end
             new_config_for_generator = parse_service_config(node.first)
-          rescue StandardError => e
-            log.error "synapse: invalid config data in ZK node at #{@discovery[discovery_key]}: #{e}"
-            new_config_for_generator = {}
           rescue ZK::Exceptions::NoNode => e
             log.error "synapse: No ZK node for config data at #{@discovery[discovery_key]}: #{e}"
+            new_config_for_generator = {}
+          rescue StandardError => e
+            log.error "synapse: invalid config data in ZK node at #{@discovery[discovery_key]}: #{e}"
             new_config_for_generator = {}
           end
         else

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -134,52 +134,39 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(subject.ping?).to be false
     end
 
-    context "when generator_config_path is defined" do
-      let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => 'some/other/path' } }
-
-      it 'reads from generator_config_path znode' do
+    context "generator_config_path" do
+      let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => generator_config_path } }
+      before :each do
         expect(subject).to receive(:watch)
         expect(subject).to receive(:discover).and_call_original
         expect(mock_zk).to receive(:children).with('some/path', {:watch=>true}).and_return(
           ["test_child_1"]
         )
-        expect(mock_zk).to receive(:get).with('some/other/path', {:watch=>true}).and_return("")
         expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_raise(ZK::Exceptions::NoNode)
 
         subject.instance_variable_set('@zk', mock_zk)
         expect(subject).to receive(:set_backends).with([],{})
-        subject.send(:watcher_callback).call
       end
 
-      it 'does not crash if there is no zk node' do
-        expect(subject).to receive(:watch)
-        expect(subject).to receive(:discover).and_call_original
-        expect(mock_zk).to receive(:children).with('some/path', {:watch=>true}).and_return(
-          ["test_child_1"]
-        )
-        expect(mock_zk).to receive(:get).with('some/other/path', {:watch=>true}).and_raise(ZK::Exceptions::NoNode)
-        expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_raise(ZK::Exceptions::NoNode)
+      context 'when generator_config_path is defined' do
+        let(:generator_config_path) { 'some/other/path' }
+        it 'reads from generator_config_path znode' do
+          expect(mock_zk).to receive(:get).with(generator_config_path, {:watch=>true}).and_return("")
 
-        subject.instance_variable_set('@zk', mock_zk)
-        expect(subject).to receive(:set_backends).with([],{})
-        subject.send(:watcher_callback).call
+          subject.send(:watcher_callback).call
+        end
+
+        it 'does not crash if there is no zk node' do
+          expect(mock_zk).to receive(:get).with(generator_config_path, {:watch=>true}).and_raise(ZK::Exceptions::NoNode)
+
+          subject.send(:watcher_callback).call
+        end
       end
-    end
-
-    context "when generator_config_path is disabled" do
-      let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => 'disabled' } }
-
-      it 'does not read from any znode' do
-        expect(subject).to receive(:watch)
-        expect(subject).to receive(:discover).and_call_original
-        expect(mock_zk).to receive(:children).with('some/path', {:watch=>true}).and_return(
-          ["test_child_1"]
-        )
-        expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_raise(ZK::Exceptions::NoNode)
-
-        subject.instance_variable_set('@zk', mock_zk)
-        expect(subject).to receive(:set_backends).with([], {})
-        subject.send(:watcher_callback).call
+      context 'when generator_config_path is disabled' do
+        let(:generator_config_path) { 'disabled' }
+        it 'does not read from any znode' do
+            subject.send(:watcher_callback).call
+        end
       end
     end
   end


### PR DESCRIPTION
Currently, if `generator_config_path` is pointed to a non-existent zk node, synapse will crash.
Let's fail more gracefully and use the default behavior of `new_config_for_generator = {}`.

@bsherrod @reissbaker 
cc @juchem @lap1817 (common contributors)