### PR TITLE
upgrade activesupport to 5.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,11 +12,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
     aws-sdk (1.67.0)
@@ -25,6 +24,8 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     coderay (1.1.0)
+    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.5-java)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -35,19 +36,19 @@ GEM
     excon (0.62.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    ffi (1.9.10)
     ffi (1.9.10-java)
     hashdiff (0.2.3)
-    i18n (0.7.0)
-    json (1.8.3)
-    json (1.8.3-java)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
+    json (1.8.6)
+    json (1.8.6-java)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
     method_source (0.8.2)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.11.3)
     multi_json (1.13.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
@@ -82,10 +83,10 @@ GEM
     slyphon-zookeeper_jar (3.3.5-java)
     spoon (0.0.4)
       ffi
-    thread_safe (0.3.5)
-    thread_safe (0.3.5-java)
+    thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     timecop (0.8.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     webmock (1.22.6)
       addressable (>= 2.3.6)
@@ -113,4 +114,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.6


### PR DESCRIPTION
https://jira.airbnb.biz/browse/TR-703

Upgrade activesupport to 5.2.1

The original test suite passes.

From the Gemfile.lock, seems the activesupport is only used for running tests