### PR TITLE
Do not crash if file_output not present

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.1)
+    synapse (0.16.2)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/config_generator/file_output.rb
+++ b/lib/synapse/config_generator/file_output.rb
@@ -31,7 +31,7 @@ class Synapse::ConfigGenerator
 
     def update_config(watchers)
       watchers.each do |watcher|
-        next if watcher.config_for_generator[name]['disabled']
+        next if writer_disabled?(watcher)
 
         unless @watcher_revisions[watcher.name] == watcher.revision
           @watcher_revisions[watcher.name] = watcher.revision
@@ -68,12 +68,20 @@ class Synapse::ConfigGenerator
       # Cleanup old services that Synapse no longer manages
       FileUtils.cd(opts['output_directory']) do
         present_files = Dir.glob('*.json')
-        managed_watchers = current_watchers.reject {|watcher| watcher.config_for_generator[name]['disabled']}
+        managed_watchers = current_watchers.reject do |watcher|
+          writer_disabled?(watcher)
+        end
         managed_files = managed_watchers.collect {|watcher| "#{watcher.name}.json"}
         files_to_purge = present_files.select {|svc| not managed_files.include?(svc)}
         log.info "synapse: purging unknown service files #{files_to_purge}" if files_to_purge.length > 0
         FileUtils.rm(files_to_purge)
       end
+    end
+
+    private
+
+    def writer_disabled?(watcher)
+      watcher.config_for_generator[name].nil? || watcher.config_for_generator[name]['disabled']
     end
   end
 end

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.1"
+  VERSION = "0.16.2"
 end

--- a/spec/lib/synapse/file_output_spec.rb
+++ b/spec/lib/synapse/file_output_spec.rb
@@ -36,6 +36,13 @@ describe Synapse::ConfigGenerator::FileOutput do
     mockWatcher
   end
 
+  let(:mockwatcher_with_no_name) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('no_name_service')
+    allow(mockWatcher).to receive(:config_for_generator).and_return({})
+    mockWatcher
+  end
+
   let(:mockwatcher_disabled) do
     mockWatcher = double(Synapse::ServiceWatcher)
     allow(mockWatcher).to receive(:name).and_return('disabled_service')
@@ -60,14 +67,14 @@ describe Synapse::ConfigGenerator::FileOutput do
   end
 
   it 'manages correct files' do
-    subject.update_config([mockwatcher_1, mockwatcher_2, mockwatcher_disabled])
+    subject.update_config([mockwatcher_1, mockwatcher_2, mockwatcher_disabled, mockwatcher_with_no_name])
     FileUtils.cd(config['file_output']['output_directory']) do
       expect(Dir.glob('*.json').sort).to eql(['example_service.json', 'foobar_service.json'])
     end
     # Should clean up after itself
     FileUtils.cd(config['file_output']['output_directory']) do
       FileUtils.touch('disabled_service.json')
-      subject.update_config([mockwatcher_1, mockwatcher_disabled])
+      subject.update_config([mockwatcher_1, mockwatcher_disabled, mockwatcher_with_no_name])
       expect(Dir.glob('*.json')).to eql(['example_service.json'])
     end
     # Should clean up after itself


### PR DESCRIPTION
Problem: synapse work if the config is `{"haproxy" => {..}, "file_output"=>{}}`
synapse crashes if config is `{"haproxy" => {..}}`
and does not contain `file_output`

Solution: Test for nil?

Tests: Added test case. Tested on a service.