### PR TITLE
warn when parsing a unknown generator name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ rvm:
   - 2.3.1
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.2)
+    synapse (0.16.3)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -334,7 +334,7 @@ class Synapse::ServiceWatcher
       #   each value should be a hash (could be empty)
       decoded.collect.each do |generator_name, generator_config|
         if !@synapse.available_generators.keys.include?(generator_name)
-          log.error "synapse: invalid generator name in ZK node at #{@discovery['path']}:" \
+          log.warn "synapse: invalid generator name in ZK node at #{@discovery['path']}:" \
             " #{generator_name}"
           next
         else

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.2"
+  VERSION = "0.16.3"
 end


### PR DESCRIPTION
When parsing an unknown `generator` from service configuration stored on `zookeeper`, `synapse` skips it but still throw `error`. `zookeeper` is designed as a generic datastore for service discovery data but not only for synapse. Therefore, there might be any random key-value pair stored under `zookeeper` node, instead of those known by synapse. This is expected and reasonable. Instead of logging as `error` level, it should make more sense to just be a `warn`.

Also, I have to limit `travis` script to use `bundler 1.17.3` in order to support legacy ruby version.
```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
	bundler requires Ruby version >= 2.3.0. The current ruby version is 1.9.1.
```

@Jason-Jian @allenlsy @chase-childers 