### PR TITLE
Add failure counters for updating config

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -68,10 +68,16 @@ module Synapse
 
           if @config_updated
             @config_updated = false
-            statsd_increment('synapse.config.update')
             @config_generators.each do |config_generator|
               log.info "synapse: configuring #{config_generator.name}"
-              config_generator.update_config(@service_watchers)
+              begin
+                config_generator.update_config(@service_watchers)
+              rescue StandardError => e
+                statsd_increment("synapse.config.update", ['result:fail', "config_name:#{config_generator.name}"])
+                log.error "synapse: update config failed for config #{config_generator.name} with exception #{e}"
+                raise e
+              end
+              statsd_increment("synapse.config.update", ['result:success', "config_name:#{config_generator.name}"])
             end
           end
 

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -68,16 +68,16 @@ module Synapse
 
           if @config_updated
             @config_updated = false
+            statsd_increment('synapse.config.update')
             @config_generators.each do |config_generator|
               log.info "synapse: configuring #{config_generator.name}"
               begin
                 config_generator.update_config(@service_watchers)
               rescue StandardError => e
-                statsd_increment("synapse.config.update", ['result:fail', "config_name:#{config_generator.name}"])
+                statsd_increment("synapse.config.update_failed", ["config_name:#{config_generator.name}"])
                 log.error "synapse: update config failed for config #{config_generator.name} with exception #{e}"
                 raise e
               end
-              statsd_increment("synapse.config.update", ['result:success', "config_name:#{config_generator.name}"])
             end
           end
 


### PR DESCRIPTION
config_generator.update_config has several steps are subjected to failure:
1. read existing config file
2. generate new config
3. write temp config file
4. replace existing config file

we need catch exception on this code path, emit success & failure counter, and log exception details

@austin-zhu @Jason-Jian @ken-experiment 