### PR TITLE
Add failure counter for haproxy reload

### DIFF
--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1340,6 +1340,7 @@ class Synapse::ConfigGenerator
       res = `#{opts['reload_command']}`.chomp
       unless $?.success?
         log.error "failed to reload haproxy via #{opts['reload_command']}: #{res}"
+        statsd_increment("synapse.haproxy.reload_failed")
         return
       end
       log.info "synapse: restarted haproxy"


### PR DESCRIPTION
haproxy restart can potentially fail and need a failure counter for monitoring purpose

@austin-zhu @ken-experiment @Jason-Jian 