### PR TITLE
Add failure counters for zookeeper watcher

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -154,7 +154,7 @@ class Synapse::ServiceWatcher
             next
           rescue StandardError => e
             log.error("synapse: #{@discovery['path']}/#{id} failed to get from ZK: #{e}")
-            statsd_increment('synapse.watcher.zk.get_failed')
+            statsd_increment('synapse.watcher.zk.get_child_failed')
             raise e
           end
 
@@ -162,8 +162,8 @@ class Synapse::ServiceWatcher
             # TODO: Do less munging, or refactor out this processing
             host, port, name, weight, haproxy_server_options, labels = deserialize_service_instance(node.first)
           rescue StandardError => e
-            log.error "synapse: invalid data in ZK node #{id} at #{@discovery['path']}: #{e}"
-            statsd_increment('synapse.watcher.zk.deserialize_failed')
+            log.error "synapse: skip child due to invalid data in ZK at #{@discovery['path']}/#{id}: #{e}"
+            statsd_increment('synapse.watcher.zk.parse_child_failed')
           else
             # find the numberic id in the node name; used for leader elections if enabled
             numeric_id = id.split('_').last
@@ -204,8 +204,8 @@ class Synapse::ServiceWatcher
             log.error "synapse: No ZK node for config data at #{@discovery[discovery_key]}: #{e}"
             new_config_for_generator = {}
           rescue StandardError => e
-            log.error "synapse: invalid config data in ZK node at #{@discovery[discovery_key]}: #{e}"
-            statsd_increment('synapse.watcher.zk.get_failed')
+            log.error "synapse: skip path due to invalid data in ZK at #{@discovery[discovery_key]}: #{e}"
+            statsd_increment('synapse.watcher.zk.get_config_failed')
             new_config_for_generator = {}
           end
         else


### PR DESCRIPTION
Add failure counters metrics for zookeeper:
1. register watcher failure
2. get data failure
3. deserialize data failure

@austin-zhu @ken-experiment @Jason-Jian 