### PR TITLE
Add retry logics for zookeeper get

### DIFF
--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -134,6 +134,28 @@ class Synapse::ServiceWatcher
       @zk.create(path, ignore: :node_exists)
     end
 
+    # get with retry to reduce failure when network connectivity is flaky or ZK is overloaded
+    def get(path, opts = {})
+      retry_limit = opts[:retry_limit] || 3
+      opts.delete(:retry_limit)
+      retry_interval = opts[:retry_interval] || 5
+      opts.delete(:retry_interval)
+      retry_count = 0
+      begin
+        if retry_count > retry_limit
+          raise RuntimeError, "synapse: get ZK path failed after retry"
+        end
+        retry_count += 1
+        node = @zk.get(path, opts)
+        raise IOError, "synapse: get ZK path return nil" if node.nil?
+        return node
+      rescue ZK::Exceptions::OperationTimeOut, IOError => e
+        log.error("synapse: get ZK #{path} failed for the #{retry_count} time: #{e}")
+        sleep retry_interval
+        retry
+      end
+    end
+
     # find the current backends at the discovery path
     def discover
       statsd_increment('synapse.watcher.zk.discovery', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"])
@@ -144,7 +166,7 @@ class Synapse::ServiceWatcher
         @zk.children(@discovery['path'], :watch => true).each do |id|
           begin
             node = statsd_time('synapse.watcher.zk.get.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
-              @zk.get("#{@discovery['path']}/#{id}")
+              get("#{@discovery['path']}/#{id}")
             end
           rescue ZK::Exceptions::NoNode => e
             # This can happen when the registry unregisters a service node between
@@ -197,7 +219,7 @@ class Synapse::ServiceWatcher
         if discovery_key
           begin
             node = statsd_time('synapse.watcher.zk.get.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
-              @zk.get(@discovery[discovery_key], :watch => true)
+              get(@discovery[discovery_key], :watch => true)
             end
             new_config_for_generator = parse_service_config(node.first)
           rescue ZK::Exceptions::NoNode => e

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -136,13 +136,13 @@ class Synapse::ServiceWatcher
 
     # get with retry to reduce failure when network connectivity is flaky or ZK is overloaded
     def zk_get_path(path, opts = {})
-      retry_limit = 3
+      retry_limit = 3 # by default retry three times on top of initial call
       if opts.has_key? :retry_limit
         retry_limit = opts[:retry_limit]
         opts.delete(:retry_limit)
       end
 
-      retry_interval = 5
+      retry_interval = 3 # by default sleep 3 seconds in-between retries
       if opts.has_key? :retry_interval
         retry_interval = opts[:retry_interval]
         opts.delete(:retry_interval)

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -105,7 +105,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
       expect(mock_zk).to receive(:get).with('test/path', {}).and_return(mock_node)
       subject.instance_variable_set('@zk', mock_zk)
-      expect(subject.send(:get, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
+      expect(subject.send(:zk_get_path, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
     end
 
     it 'handle zk get retrun nill failure' do
@@ -114,7 +114,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
       expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
       subject.instance_variable_set('@zk', mock_zk)
-      expect{subject.send(:get, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
+      expect{subject.send(:zk_get_path, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
     end
 
     it 'handle zk get timeout success' do
@@ -124,7 +124,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
       expect(mock_zk).to receive(:get).with('test/path', {}).and_return(mock_node)
       subject.instance_variable_set('@zk', mock_zk)
-      expect(subject.send(:get, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
+      expect(subject.send(:zk_get_path, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
     end
 
     it 'handle zk get timeout failure' do
@@ -133,7 +133,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
       expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
       subject.instance_variable_set('@zk', mock_zk)
-      expect{subject.send(:get, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
+      expect{subject.send(:zk_get_path, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
     end
 
     it 'reacts to zk push events' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -98,6 +98,44 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(subject.send(:parse_service_config, config_for_generator_invalid_string)).to eql(parsed_config_for_generator_invalid)
     end
 
+    it 'handle zk get retrun nil success' do
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(mock_node)
+      subject.instance_variable_set('@zk', mock_zk)
+      expect(subject.send(:get, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
+    end
+
+    it 'handle zk get retrun nill failure' do
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(nil)
+      subject.instance_variable_set('@zk', mock_zk)
+      expect{subject.send(:get, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
+    end
+
+    it 'handle zk get timeout success' do
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_return(mock_node)
+      subject.instance_variable_set('@zk', mock_zk)
+      expect(subject.send(:get, 'test/path', :retry_limit => 5, :retry_interval => 0)).to eql mock_node
+    end
+
+    it 'handle zk get timeout failure' do
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      expect(mock_zk).to receive(:get).with('test/path', {}).and_raise(ZK::Exceptions::OperationTimeOut)
+      subject.instance_variable_set('@zk', mock_zk)
+      expect{subject.send(:get, 'test/path', :retry_interval => 0)}.to raise_error(RuntimeError)
+    end
+
     it 'reacts to zk push events' do
       expect(subject).to receive(:watch)
       expect(subject).to receive(:discover).and_call_original
@@ -105,7 +143,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(mock_zk).to receive(:children).with('some/path', {:watch=>true}).and_return(
         ["test_child_1"]
       )
-      expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_return(mock_node)
+      expect(mock_zk).to receive(:get).with('some/path/test_child_1', {}).and_return(mock_node)
       subject.instance_variable_set('@zk', mock_zk)
       expect(subject).to receive(:set_backends).with([service_data.merge({'id' => 1})], parsed_config_for_generator)
       subject.send(:watcher_callback).call
@@ -118,7 +156,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         ["test_child_1"]
       )
       expect(mock_zk).to receive(:get).with('some/path', {:watch=>true}).and_return("")
-      expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_raise(ZK::Exceptions::NoNode)
+      expect(mock_zk).to receive(:get).with('some/path/test_child_1', {}).and_raise(ZK::Exceptions::NoNode)
 
       subject.instance_variable_set('@zk', mock_zk)
       expect(subject).to receive(:set_backends).with([],{})
@@ -142,7 +180,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         expect(mock_zk).to receive(:children).with('some/path', {:watch=>true}).and_return(
           ["test_child_1"]
         )
-        expect(mock_zk).to receive(:get).with('some/path/test_child_1').and_raise(ZK::Exceptions::NoNode)
+        expect(mock_zk).to receive(:get).with('some/path/test_child_1', {}).and_raise(ZK::Exceptions::NoNode)
 
         subject.instance_variable_set('@zk', mock_zk)
         expect(subject).to receive(:set_backends).with([],{})


### PR DESCRIPTION
zookeeper get can return nil or throw timeout exception, when network is flaky or zookeeper is overloaded.

adding retry logics (by default 3 times with 5 second interval) can alleviate the problem.

if all retries failed, throw runtime error forcing the process to re-establish zookeeper connections.

@austin-zhu @ken-experiment 