### PR TITLE
Fix synapse watch lost during zookeeper server reboot

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.5)
+    synapse (0.16.6)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -254,7 +254,10 @@ class Synapse::ServiceWatcher
       log.debug "synapse: setting watch at #{@discovery['path']}"
 
       statsd_time('synapse.watcher.zk.watch.elapsed_time', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"]) do
-        @watcher = @zk.register(@discovery['path'], &watcher_callback) unless @watcher
+        unless @watcher
+          @watcher = @zk.register(@discovery['path'], &watcher_callback)
+          log.info "synapse: register watcher at path #{@discovery['path']}"
+        end
 
         # Verify that we actually set up the watcher.
         unless @zk.exists?(@discovery['path'], :watch => true)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -256,7 +256,7 @@ class Synapse::ServiceWatcher
       statsd_time('synapse.watcher.zk.watch.elapsed_time', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"]) do
         unless @watcher
           @watcher = @zk.register(@discovery['path'], &watcher_callback)
-          log.info "synapse: register watcher at path #{@discovery['path']}"
+          log.info "synapse: register watch at #{@discovery['path']}"
         end
 
         # Verify that we actually set up the watcher.

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -347,7 +347,9 @@ class Synapse::ServiceWatcher
         # http://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkSessions
         @zk.on_connected do
           log.info "synapse: ZK client has reconnected #{@name}"
-          # zookeeper watcher is one-time trigger, and be lost when disconnected
+          # random backoff to avoid refresh at the same time
+          sleep rand(10)
+          # zookeeper watcher is one-time trigger, and can be lost when disconnected
           # https://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkWatches
           @watcher.unsubscribe unless @watcher.nil?
           @watcher = nil

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.5"
+  VERSION = "0.16.6"
 end


### PR DESCRIPTION
we recently discover synapse 'stuck' issue in production: during zookeeper server reboot, watcher was lost forever for one zookeeper path

The key takeways are here:
1. zookeeper watcher is one-time trigger, if one watcher is lost and not re-set, any future events associated will not be notified.
2. zookeeper watcher setting involves two steps: 1. register watcher if it doesn't exist, 2 enable watcher by get/children call (with :watch = true)
2. during zookeeper server restart, client can potentially enter two states: session expire or reconnecting, the currently implementation doesn't handle reconnecting.
3. watcher can get lost when client is disconnected from server.

The fix is to listen on reconnect state, and then re-register and re-enable watcher.

Also log entry when watchers are registered and enabled (both parent and children), for better observability in future operation

@austin-zhu @Jason-Jian 

 