### PR TITLE
Remove on_connecting for less threads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.6)
+    synapse (0.16.7)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -337,12 +337,6 @@ class Synapse::ServiceWatcher
           zk_cleanup
         end
 
-        # handle session reconnecting
-        # http://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkSessions
-        @zk.on_connecting do
-          log.info "synapse: ZK client is attempting to reconnect #{@name}"
-        end
-
         # handle session connected after reconnecting
         # http://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkSessions
         @zk.on_connected do

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.6"
+  VERSION = "0.16.7"
 end


### PR DESCRIPTION
due to zk-client implementation, it keeps a single thread open after registering the callback in order to guarantee high concurrency https://github.com/zk-ruby/zk/wiki/EventDeliveryModel

we need keep number of callback per watch as few as possible.

@austin-zhu @Jason-Jian 