### PR TITLE
Update `aws-sdk` for Security Vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.7)
+    synapse (0.16.8)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)
@@ -32,26 +32,25 @@ GEM
       excon (>= 0.47.0)
       multi_json
     dogstatsd-ruby (3.3.0)
-    excon (0.62.0)
+    excon (0.64.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    ffi (1.9.10)
     ffi (1.9.10-java)
     hashdiff (0.2.3)
     i18n (0.7.0)
-    json (1.8.3)
-    json (1.8.3-java)
+    json (1.8.6)
+    json (1.8.6-java)
     little-plugger (1.1.4)
     logging (1.8.2)
       little-plugger (>= 1.1.3)
       multi_json (>= 1.8.4)
     method_source (0.8.2)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.4.0)
     minitest (5.9.0)
     multi_json (1.13.1)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.6.8.1-java)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.3-java)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -113,4 +112,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.7"
+  VERSION = "0.16.8"
 end


### PR DESCRIPTION
Update the Dependencies of `aws-sdk` via `bundle update aws-sdk`.

This is to close known vulnerabilities with `nokogiri` and `ffi`:
https://github.com/airbnb/synapse/network/alert/Gemfile.lock/nokogiri/open
https://github.com/airbnb/synapse/network/alert/Gemfile.lock/ffi/open

