### PR TITLE
Throttle discover in zookeeper service watcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.7)
+    synapse (0.16.8)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.7"
+  VERSION = "0.16.8"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -172,6 +172,15 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(subject.ping?).to be false
     end
 
+    it 'throttles discovery if discovery_jitter is set' do
+      discovery['discovery_jitter'] = 25
+      expect(subject).to receive(:watch)
+      expect(subject).to receive(:discover)
+      expect(subject).to receive(:sleep).with(25)
+      subject.instance_variable_set(:@watcher, instance_double(ZK::EventHandlerSubscription))
+      subject.send(:watcher_callback).call
+    end
+
     context "generator_config_path" do
       let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => generator_config_path } }
       before :each do


### PR DESCRIPTION
## Problem:
When large service deploys, services  depending on this large service is constantly reloading zookeeper get on leaf nodes.

Unmodified:  During 1000 node service deploy, a single dependent service refreshed 7 times(7000 ZK.GET) in 2 minutes. 
```
ramya_krishnan@i-05bae5ca90fc95bb4:/etc/service/synapse/log testbox-14-production $ grep 06:47 current |grep discovered|grep monorail
I, [2019-05-31T06:47:13.992250 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:47:26.743540 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:47:41.702985 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
ramya_krishnan@i-05bae5ca90fc95bb4:/etc/service/synapse/log testbox-14-production $ grep 06:48 current |grep discovered|grep monorail
I, [2019-05-31T06:48:06.650514 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:48:20.541084 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:48:29.369780 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:48:44.266013 #20084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
```

## Solution:
Throttle watch and discovery if a `discovery_jitter` variable is set.

With 25 second discovery_throttle number of reloads reduce to 3 (or 3000 GETs).
```
ramya_krishnan@i-0c029d8e0c2164573:/etc/service/synapse/log testbox-14-production $ grep 06:47 current |grep discovered|grep monorail
I, [2019-05-31T06:47:13.772293 #29463]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
ramya_krishnan@i-0c029d8e0c2164573:/etc/service/synapse/log testbox-14-production $ grep 06:48 current |grep discovered|grep monorail
I, [2019-05-31T06:48:05.142832 #29463]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
I, [2019-05-31T06:48:44.863371 #29463]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered XXXX backends for service monorail
```
![Screen Shot 2019-05-31 at 12 03 35 AM](https://user-images.githubusercontent.com/3836498/58687932-e7fbf580-8337-11e9-8614-b04f505408e2.png)


Concerns regarding delayed synapse changes.
* HAProxy health checks should be faster to notice nerve down scenario.
* If this is a normal deploy, service is expected to serve traffic few seconds after nerve is down.

