### PR TITLE
Improve on_connected callback to avoid reconnect storm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3-p551
+  - 1.9.3
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3
+  - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.11)
+    synapse (0.16.12)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -367,12 +367,14 @@ class Synapse::ServiceWatcher
         # http://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkSessions
         @zk.on_connected do
           log.info "synapse: ZK client has reconnected #{@name}"
-          # random backoff to avoid checking and refreshing all watchers at the same time
-          sleep rand(10)
           unless test_and_set_reconnect_time(Time.now)
             log.info "synapse: ZK client skip since last reconnect is too close #{@name}"
             return
           end
+
+          # random backoff to avoid checking and refreshing all watchers at the same time
+          sleep rand(30)
+
           # zookeeper watcher is one-time trigger, and can be lost when disconnected
           # https://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkWatches
           # only need re-enable watcher on parent path and children list

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -372,7 +372,7 @@ class Synapse::ServiceWatcher
             return
           end
 
-          # random backoff to avoid checking and refreshing all watchers at the same time
+          # random backoff to avoid refreshing all watchers at the same time
           sleep rand(30)
 
           # zookeeper watcher is one-time trigger, and can be lost when disconnected

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -380,7 +380,7 @@ class Synapse::ServiceWatcher
           @last_reconnect_time = now
           # zookeeper watcher is one-time trigger, and can be lost when disconnected
           # https://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkWatches
-          # only need reanble watcher on parent path and children list
+          # only need re-enable watcher on parent path and children list
           log.info "synapse: ZK client refresh watcher after reconnected #{@name}"
           if @zk.exists?(@discovery['path'], :watch => true)
             @zk.children(@discovery['path'], :watch => true)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -369,9 +369,9 @@ class Synapse::ServiceWatcher
           log.info "synapse: ZK client has reconnected #{@name}"
           # random backoff to avoid checking and refreshing all watchers at the same time
           sleep rand(10)
-		  now = Time.now
+          now = Time.now
           # ensure there is only one refresh can happen within a time window
-          if !@last_reconnect_time.nil? && (now - @last_connect_time) < 60
+          if !@last_reconnect_time.nil? && (now - @last_reconnect_time) < 60
             log.info "synapse: ZK client skip since last reconnect is too close #{@name}"
             return
           end

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.11"
+  VERSION = "0.16.12"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -149,6 +149,17 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       subject.send(:watcher_callback).call
     end
 
+    it 'test and set reconnect time' do
+      now = Time.now
+      expect(subject.send(:test_and_set_reconnect_time, now)).to be true
+      now += 10
+      expect(subject.send(:test_and_set_reconnect_time, now)).to be false
+      now += 50
+      expect(subject.send(:test_and_set_reconnect_time, now)).to be true
+      now += 60
+      expect(subject.send(:test_and_set_reconnect_time, now)).to be true
+    end
+
     it 'handles zk consistency issues' do
       expect(subject).to receive(:watch)
       expect(subject).to receive(:discover).and_call_original


### PR DESCRIPTION
The on_connected callback was originally introduced to handle an issue that zookeeper session got stuck (will not receive zookeeper watch event forever), during a connection lost and reconnect.

But we discovered some side-effect of this fix, there are multiple on_connected callback get triggered for a single disconnect and reconnect (here seems other people are facing the same issue: https://github.com/zk-ruby/zk-eventmachine/issues/2). And since we do reset zookeeper watcher by read everything. This creates substantial load on zookeeper.

Here are two optimizations introduced by this change:
1. ensure there is only one watcher refresh within a time window (e.g. 60 seconds) no matter how many on_connected callback gets triggered
2. optimize the watcher refresh by just re-enable (parent and children) watcher, to avoid zk get storm

@austin-zhu @Jason-Jian @allenlsy @Ramyak 

Before (reboot zookeeper twice, got 3 on_connected each time):
![image](https://user-images.githubusercontent.com/1474346/59474432-a1a89b00-8dfb-11e9-82cb-50fa5820f1fc.png)

After (reboot zookeeper server once, got watcher refresh once):
<img width="1434" alt="Screen Shot 2019-06-13 at 7 39 21 PM" src="https://user-images.githubusercontent.com/1474346/59480077-0d96fd80-8e14-11e9-9f4b-46eade65464e.png">

reboot zookeeper server twice, only got watcher refresh twice
<img width="1242" alt="Screen Shot 2019-06-13 at 8 48 56 PM" src="https://user-images.githubusercontent.com/1474346/59482195-c2351d00-8e1c-11e9-9cc3-cce11f381ede.png">

