### PR TITLE
Avoid discovery_jitter sleep on first event

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.10)
+    synapse (0.16.11)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.10"
+  VERSION = "0.16.11"
 end


### PR DESCRIPTION
If we get an event, do not sleep (discovery_jitter seconds)

```
Previous discovery

I, [2019-06-14T01:17:54.553668 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 3 backends for service sssp-test
I, [2019-06-14T01:17:54.579559 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 3 backends for service sssp-test-regional
I, [2019-06-14T01:17:54.592510 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 3 backends for service sssp-test-local-az

15 seconds no activity. Then discovery without sleep

I, [2019-06-14T01:18:30.594380 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 2 backends for service sssp-test-regional
I, [2019-06-14T01:18:30.595322 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 2 backends for service sssp-test
I, [2019-06-14T01:18:30.597157 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 2 backends for service sssp-test-local-az

Subsequent jitter
I, [2019-06-14T01:18:31.114913 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: sleeping for discovery_jitter=25 seconds for service:sssp-test-regional
I, [2019-06-14T01:18:31.114975 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: sleeping for discovery_jitter=25 seconds for service:sssp-test-local-az
I, [2019-06-14T01:18:31.115191 #18252]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: sleeping for discovery_jitter=25 seconds for service:sssp-test

```


