### PR TITLE
Remove on_connected to avoid reconnect storm

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.9)
+    synapse (0.16.10)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -359,19 +359,6 @@ class Synapse::ServiceWatcher
           zk_cleanup
         end
 
-        # handle session connected after reconnecting
-        # http://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkSessions
-        @zk.on_connected do
-          log.info "synapse: ZK client has reconnected #{@name}"
-          # random backoff to avoid refresh at the same time
-          sleep rand(10)
-          # zookeeper watcher is one-time trigger, and can be lost when disconnected
-          # https://zookeeper.apache.org/doc/r3.3.5/zookeeperProgrammers.html#ch_zkWatches
-          @watcher.unsubscribe unless @watcher.nil?
-          @watcher = nil
-          watcher_callback.call
-        end
-
         # the path must exist, otherwise watch callbacks will not work
         statsd_time('synapse.watcher.zk.create_path.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
           create(@discovery['path'])

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.9"
+  VERSION = "0.16.10"
 end


### PR DESCRIPTION
We discovered zk client bug that could potentially cause watcher refresh storm and zk overload, when zk server restart

while we are waiting for the fix to get reviewed and well tested:
https://github.com/airbnb/synapse/pull/292

For now remove on_connected callback to be safe

@Jason-Jian @allenlsy @Ramyak