### PR TITLE
Add path encoding optimization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.16.13)
+    synapse (0.17.0)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -106,7 +106,7 @@ class Synapse::ServiceWatcher
     def config_for_generator
       Marshal.load( Marshal.dump(@config_for_generator))
     end
-    
+
     def backends
       filtered = backends_filtered_by_labels
 
@@ -219,7 +219,7 @@ class Synapse::ServiceWatcher
     def update_config_for_generator(new_config_for_generator)
       if new_config_for_generator.empty?
         log.info "synapse: no config_for_generator data from #{name} for" \
-              " service #{@name}; keep existing config_for_generator: #{@config_for_generator.inspect}"
+              " service #{@name}; keep existing config_for_generator"
         return false
       else
         log.info "synapse: discovered config_for_generator for service #{@name}"

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -272,7 +272,7 @@ class Synapse::ServiceWatcher
       statsd_time('synapse.watcher.zk.watch.elapsed_time', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"]) do
         unless @watcher
           @watcher = @zk.register(@discovery['path'], &watcher_callback)
-          log.info "synapse: register watch at #{@discovery['path']}"
+          log.debug "synapse: register watch at #{@discovery['path']}"
         end
 
         # Verify that we actually set up the watcher.

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -180,7 +180,7 @@ class Synapse::ServiceWatcher
 
         new_backends = []
         zk_children = @zk.children(@discovery['path'], :watch => true)
-        statsd_gauge('synapse.watcher.zk.children.bytes_received', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
+        statsd_gauge('synapse.watcher.zk.children.bytes', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
         log.debug "synapse: set watch for children at #{@discovery['path']}"
         zk_children.each do |id|
           if id.start_with?('base64_')

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -9,6 +9,12 @@ class Synapse::ServiceWatcher
     NUMBERS_RE = /^\d+$/
     MIN_JITTER = 0
     MAX_JITTER = 120
+    # When creating a znode you can also request that ZooKeeper append a monotonically increasing
+    # counter to the end of path. This counter is unique to the parent znode. The counter has a
+    # format of %010d -- that is 10 digits with 0 (zero) padding (the counter is formatted in this
+    # way to simplify sorting), i.e. "0000000001".
+    # https://zookeeper.apache.org/doc/current/zookeeperProgrammers.html#Sequence+Nodes+--+Unique+Naming
+    SEQUENCE_NODE_COUNTER_LENGTH = 10
 
     @@zk_pool = {}
     @@zk_pool_count = {}
@@ -399,7 +405,7 @@ class Synapse::ServiceWatcher
     end
 
     def parse_child_name(child_name)
-      numeric_id = child_name[child_name.length-10..child_name.length]
+      numeric_id = child_name[child_name.length-SEQUENCE_NODE_COUNTER_LENGTH..child_name.length]
       child_name = child_name.chomp("_#{numeric_id}")
       obj = JSON.parse(Base64.urlsafe_decode64(child_name))
       obj['numeric_id'] = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -183,7 +183,7 @@ class Synapse::ServiceWatcher
         statsd_gauge('synapse.watcher.zk.children.bytes', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
         log.debug "synapse: set watch for children at #{@discovery['path']}"
         zk_children.each do |id|
-          if id.start_with?('base64_')
+          if id.start_with?(CHILD_NAME_ENCODING_PREFIX)
             node = parse_base64_encoded_prefix(id)
             if node != nil
               log.debug "synapse: discovered backend with child name at #{node['name']} #{node['host']}:#{node['port']} for service #{@name}"

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -3,6 +3,7 @@ require "synapse/service_watcher/base"
 require 'thread'
 require 'zk'
 require 'base64'
+require 'objspace'
 
 class Synapse::ServiceWatcher
   class ZookeeperWatcher < BaseWatcher
@@ -185,6 +186,7 @@ class Synapse::ServiceWatcher
 
         new_backends = []
         zk_children = @zk.children(@discovery['path'], :watch => true)
+        statsd_gauge('synapse.watcher.zk.children.bytes_received', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
         log.debug "synapse: set watch for children at #{@discovery['path']}"
         zk_children.each do |id|
           if id.start_with?('base64_')

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -185,12 +185,12 @@ class Synapse::ServiceWatcher
 
         new_backends = []
         zk_children = @zk.children(@discovery['path'], :watch => true)
-        log.info "synapse: set watch for children at #{@discovery['path']}"
+        log.debug "synapse: set watch for children at #{@discovery['path']}"
         zk_children.each do |id|
           if id.start_with?('base64_')
             node = parse_child_name(id)
             if node != nil
-              log.info "synapse: discovered backend with child name #{node} for service #{@name}"
+              log.debug "synapse: discovered backend with child name #{node} for service #{@name}"
               new_backends << node
               next
             end
@@ -223,7 +223,7 @@ class Synapse::ServiceWatcher
             numeric_id = id.split('_').last
             numeric_id = NUMBERS_RE =~ numeric_id ? numeric_id.to_i : nil
 
-            log.info "synapse: discovered backend with child data at #{host}:#{port} for service #{@name}"
+            log.debug "synapse: discovered backend with child data at #{host}:#{port} for service #{@name}"
             new_backends << {
               'name' => name, 'host' => host, 'port' => port,
               'id' => numeric_id, 'weight' => weight,
@@ -288,7 +288,7 @@ class Synapse::ServiceWatcher
           zk_cleanup
         end
       end
-      log.info "synapse: set watch for parent at #{@discovery['path']}"
+      log.debug "synapse: set watch for parent at #{@discovery['path']}"
     end
 
     # handles the event that a watched path has changed in zookeeper

--- a/lib/synapse/statsd.rb
+++ b/lib/synapse/statsd.rb
@@ -17,6 +17,10 @@ module Synapse
       end
     end
 
+    def statsd_gauge(key, val, tags = [])
+      statsd.gauge(key, val, tags: tags, sample_rate: sample_rate_for(key))
+    end
+
     class << self
       include Logging
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.16.13"
+  VERSION = "0.17.0"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -241,6 +241,38 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         end
       end
     end
+
+    context "use_path_encoding" do
+      it 'parse child name with az' do
+        node = {
+          'host' => '127.0.0.1',
+          'port' => '3000',
+          'labels' => {
+            'az' => 'us-east-1a'
+          }
+        }
+        encoded_str = Base64.urlsafe_encode64(JSON(node))
+        node['numeric_id'] = 5
+        expect(subject.send(:parse_child_name, "#{encoded_str}_0000000005")).to eql(node)
+      end
+
+      it 'parse child name without az' do
+        node = {
+          'host' => '127.0.0.1',
+          'port' => '3000',
+        }
+        encoded_str = Base64.urlsafe_encode64(JSON(node))
+        node['numeric_id'] = 5
+        expect(subject.send(:parse_child_name, "#{encoded_str}_0000000005")).to eql(node)
+      end
+
+      it 'parse child name returns nil' do
+        expect(subject.send(:parse_child_name, "i-xxxxxxx_0000000005")).to be nil
+      end
+
+    end
+
+
   end
 
   context 'ZookeeperDnsWatcher' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -248,12 +248,13 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
           'host' => '127.0.0.1',
           'port' => '3000',
           'labels' => {
+            'region' => 'us-east-1',
             'az' => 'us-east-1a'
           }
         }
         encoded_str = Base64.urlsafe_encode64(JSON(node))
-        node['numeric_id'] = 5
-        expect(subject.send(:parse_child_name, "#{encoded_str}_0000000005")).to eql(node)
+        node['numeric_id'] = 3
+        expect(subject.send(:parse_child_name, "base64_#{encoded_str}_0000000003")).to eql(node)
       end
 
       it 'parse child name without az' do
@@ -263,7 +264,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         }
         encoded_str = Base64.urlsafe_encode64(JSON(node))
         node['numeric_id'] = 5
-        expect(subject.send(:parse_child_name, "#{encoded_str}_0000000005")).to eql(node)
+        expect(subject.send(:parse_child_name, "base64_#{encoded_str}_0000000005")).to eql(node)
       end
 
       it 'parse child name returns nil' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -243,7 +243,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     end
 
     context "use_path_encoding" do
-      it 'parse child name with az' do
+      it 'parse base64 encoded prefix' do
         node = {
           'host' => '127.0.0.1',
           'port' => '3000',
@@ -253,27 +253,32 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
           }
         }
         encoded_str = Base64.urlsafe_encode64(JSON(node))
-        node['numeric_id'] = 3
-        expect(subject.send(:parse_child_name, "base64_#{encoded_str}_0000000003")).to eql(node)
+        child_name = "base64_#{encoded_str.length}_#{encoded_str}_0000000003"
+        expect(subject.send(:parse_base64_encoded_prefix, child_name)).to eql(node)
       end
 
-      it 'parse child name without az' do
+      it 'parse based64 encoded prefix without labels' do
         node = {
           'host' => '127.0.0.1',
           'port' => '3000',
         }
         encoded_str = Base64.urlsafe_encode64(JSON(node))
-        node['numeric_id'] = 5
-        expect(subject.send(:parse_child_name, "base64_#{encoded_str}_0000000005")).to eql(node)
+        child_name = "base64_#{encoded_str.length}_#{encoded_str}_0000000005"
+        expect(subject.send(:parse_base64_encoded_prefix, child_name)).to eql(node)
       end
 
-      it 'parse child name returns nil' do
-        expect(subject.send(:parse_child_name, "i-xxxxxxx_0000000005")).to be nil
+      it 'parse base64 encoded prefix returns nil' do
+        expect(subject.send(:parse_base64_encoded_prefix, "i-xxxxxxx_0000000005")).to be nil
       end
 
+      it 'parse numeric id suffix' do
+        expect(subject.send(:parse_numeric_id_suffix, "i-xxxxxxx_0000000005")).to be 5
+      end
+
+      it 'parse numeric id suffix returns nil' do
+        expect(subject.send(:parse_numeric_id_suffix, "i-xxxxxxx_60da")).to be nil
+      end
     end
-
-
   end
 
   context 'ZookeeperDnsWatcher' do


### PR DESCRIPTION
### Summary:

1. decode zk child name with base64 encoding to get ip, port, labels etc.
2. ensure backward compatibility: synapse with path encoding enabled works with old version of nerve safely
3. use variable length decoding to make schema more flexible:
   a. prefix is optional encoded json
   b. suffix is optional sequence number 
4. make decoding more producer driven
   a. feature is enabled based on child name prefixed with protocol name `base64_`
   b. json content is decided by producer encoding, no fields picking


The counterpart nerve change:
https://github.com/airbnb/nerve/pull/114

### Test Plan:

test synapse log:
```
{
    "services": {
        "mango-test": {
            "discovery": {
                "method": "zookeeper",
                "generator_config_path": "disabled",
                "use_path_encoding": true,
                "path": "/mango-test/services",
                "hosts": [
                    "127.0.0.1:2181",
                ],
                "label_filter": {
                    "label": "az",
                    "value": "<%= ENV['AWS_AZ'] %>",
                    "condition": "equals"
                }
            },
            "haproxy": {
              ...
            },
            "use_previous_backends": false
        }
    },
    "haproxy": {
      ...
    }
}

```

```
zkCli ls /mango-test/services
Connecting to localhost:2181

WATCHER::

WatchedEvent state:SyncConnected type:None path:null
[eyJob3N0IjoiMTI3LjAuMC4xIiwicG9ydCI6MzAwMCwibGFiZWxzIjp7ImF6IjoidXMtZWFzdC0xYSJ9fQ==_0000000008]
```

```
synapse --config synapse.json
I, [2019-07-02T18:28:32.768010 #2188]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
W, [2019-07-02T18:28:32.883326 #2188]  WARN -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: `label_filter` parameter is deprecated; use `label_filters` -- an array
W, [2019-07-02T18:28:32.883387 #2188]  WARN -- Synapse::ConfigGenerator::Haproxy: synapse: service mango-test: haproxy config does not include a port; only backend sections for the service will be created; you must move traffic there manually using configuration in `extra
_sections`
I, [2019-07-02T18:28:32.883434 #2188]  INFO -- Synapse::Synapse: synapse: starting...
I, [2019-07-02T18:28:32.884251 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test @ cluster 127.0.0.1:2181 path: /mango-test/services
I, [2019-07-02T18:28:32.884327 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 127.0.0.1:2181
I, [2019-07-02T18:28:32.884363 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: creating pooled connection to 127.0.0.1:2181
I, [2019-07-02T18:28:32.888046 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: successfully created zk connection to 127.0.0.1:2181
I, [2019-07-02T18:28:32.888127 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-02T18:28:32.889992 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: register watch at /mango-test/services
I, [2019-07-02T18:28:32.890500 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for parent at /mango-test/services
I, [2019-07-02T18:28:32.890556 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-test
I, [2019-07-02T18:28:32.891058 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for children at /mango-test/services
I, [2019-07-02T18:28:32.891161 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered backend with child name {"host"=>"127.0.0.1", "port"=>3000, "labels"=>{"az"=>"us-east-1a"}, "numeric_id"=>7} for service mango-test
I, [2019-07-02T18:28:32.891203 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-test
I, [2019-07-02T18:28:32.891235 #2188]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-test for service mango-test; keep existing config_for_generator: {"haproxy"=>{"server_options"=>"check port %{port} inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /etc/internal_x509/securestack_ca_chain.pem crt /etc/internal_x509/securestack_client_private_bundle.pem", "server_port_override"=>nil, "backend"=>["option http-server-close"], "frontend"=>["acl use_local_backend nbsrv(sssp-local-az) ge 3", "acl use_regional_backend nbsrv(sssp-regional) ge 3", "use_backend sssp-local-az if use_local_backend", "use_backend sssp-regional if use_regional_backend", "bind ::1:3526"], "listen"=>["mode http", "option tcp-check", "option httplog"]}}
```

compatibility test:
mango-test (synapse 0.16.13)-> mango-production (nerve 0.9.0)
<img width="881" alt="mango-production-enabled" src="https://user-images.githubusercontent.com/1474346/60632302-c1f3c600-9db9-11e9-9194-4ced31f99249.png">

<img width="1440" alt="old synapse with new nerve" src="https://user-images.githubusercontent.com/1474346/60632290-b1435000-9db9-11e9-80e0-1641e7e660ba.png">

mango-test (synapse 0.17.0) -> mango-production (nerve 0.9.0)
<img width="1226" alt="Screen Shot 2019-07-03 at 5 30 42 PM" src="https://user-images.githubusercontent.com/1474346/60632285-ac7e9c00-9db9-11e9-9d70-e81d4d313a90.png">

mango-test (synapse 0.17.0) -> mango-canary (nerve 0.8.8)
<img width="1206" alt="Screen Shot 2019-07-03 at 5 31 59 PM" src="https://user-images.githubusercontent.com/1474346/60632283-a8527e80-9db9-11e9-99e7-757e6bd72ff6.png">

### Reviewers:

@austin-zhu @allenlsy @Jason-Jian @Ramyak 