### PR TITLE
Add option for load testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.10
   - 2.2.5

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -123,7 +123,14 @@ module Synapse
     def create_service_watchers(services={})
       service_watchers = []
       services.each do |service_name, service_config|
-        service_watchers << ServiceWatcher.create(service_name, service_config, self)
+        if service_config.has_key?('load_test_concurrency')
+          concurrency = service_config['load_test_concurrency']
+          concurrency.times do |i|
+            service_watchers << ServiceWatcher.create("#{service_name}_#{i}", service_config, self)
+          end
+        else
+          service_watchers << ServiceWatcher.create(service_name, service_config, self)
+        end
       end
 
       return service_watchers


### PR DESCRIPTION
For load testing purpose
1. add option load_test_concurrency to launch multiple service watchers

Test with local zookeeper and test config:
```
{
    "services": {
        "mango-test": {
            "discovery": {
                "method": "zookeeper",
                "generator_config_path": "disabled",
                "use_path_encoding": true,
                "path": "/mango-test/services",
                "hosts": [
                    "127.0.0.1:2181",
                ],
                "label_filter": {
                    "label": "az",
                    "value": "<%= ENV['AWS_AZ'] %>",
                    "condition": "equals"
                }
            },
            "haproxy": {
                "server_options": "check port %{port} inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /etc/internal_x509/securestack_ca_chain.pem crt /etc/internal_x509/securestack_client_private_bundle.pem",
                "listen": [
                    "mode http",
                    "option tcp-check",
                    "option httplog"
                ],
                "backend": [
                    "option http-server-close"
                ],
                "frontend": [
                    "acl use_local_backend nbsrv(sssp-local-az) ge 3",
                    "acl use_regional_backend nbsrv(sssp-regional) ge 3",
                    "use_backend sssp-local-az if use_local_backend",
                    "use_backend sssp-regional if use_regional_backend",
                    "bind ::1:3526"
                ]
            },
            "use_previous_backends": false,
            "load_test_concurrency": 10
        }
    },
    "haproxy": {
        "reload_command": "sudo service haproxy reload",
        "restart_interval": 20,
        "restart_jitter": 0.3,
        "config_file_path": "/Users/anson/test/haproxy.cfg",
        "socket_file_path": [
            "/Users/anson/test/stats1.sock"
        ],
        "do_writes": true,
        "do_reloads": false,
        "do_socket": false,
        "state_file_path": "/Users/anson/test/haproxy_state_file.json",
        "state_file_ttl": 86400,
        "global": [
            "daemon",
            "spread-checks 2",
            "user    haproxy",
            "group   haproxy",
            "maxconn 8192",
            "nbproc 1",
            "log     127.0.0.1 local1",
            "cpu-map 1 0",
            "stats socket /var/haproxy/stats1_ro.sock group dd-agent mode 660 level user process 1",
            "stats socket /var/haproxy/stats1.sock group smartstack mode 660 level admin process 1"
        ],
        "defaults": [
            "log      global",
            "option   dontlognull",
            "option   log-separate-errors",
            "maxconn  2000",
            "timeout  connect 5s",
            "timeout  check   5s",
            "timeout  client  50s",
            "timeout  server  50s",
            "option   redispatch",
            "retries  3",
            "balance  static-rr",
            "option http-tunnel",
            "option splice-auto"
        ],
        "extra_sections": {
            "listen stats_nbproc1": [
                "bind :3212",
                "mode http",
                "stats enable",
                "stats uri /",
                "bind-process 1"
            ]
        }
    }
}
```

```
I, [2019-07-08T14:39:37.789296 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test_7 @ cluster 127.0.0.1:2181 path: /mango-test/services
I, [2019-07-08T14:39:37.789320 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 127.0.0.1:2181
I, [2019-07-08T14:39:37.789336 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: re-using existing zookeeper connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.789377 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.791264 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: register watch at /mango-test/services
I, [2019-07-08T14:39:37.791792 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for parent at /mango-test/services
I, [2019-07-08T14:39:37.791994 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-test_7
I, [2019-07-08T14:39:37.792380 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for children at /mango-test/services
I, [2019-07-08T14:39:37.796558 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-test_7
I, [2019-07-08T14:39:37.796620 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-test_7 for service mango-test_7; keep existing config_for_generator: {"haproxy"=>{"server_options"=>"check port %{port} inter 30s do
wninter 1s rise 1 fall 2 ssl verify required ca-file /etc/internal_x509/securestack_ca_chain.pem crt /etc/internal_x509/securestack_client_private_bundle.pem", "server_port_override"=>nil, "backend"=>["option http-server-close"], "frontend"=>["acl use_local_backend nbsrv(
sssp-local-az) ge 3", "acl use_regional_backend nbsrv(sssp-regional) ge 3", "use_backend sssp-local-az if use_local_backend", "use_backend sssp-regional if use_regional_backend", "bind ::1:3526"], "listen"=>["mode http", "option tcp-check", "option httplog"]}}
I, [2019-07-08T14:39:37.796743 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test_8 @ cluster 127.0.0.1:2181 path: /mango-test/services
I, [2019-07-08T14:39:37.796911 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 127.0.0.1:2181
I, [2019-07-08T14:39:37.796930 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: re-using existing zookeeper connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.796972 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.804015 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: register watch at /mango-test/services
I, [2019-07-08T14:39:37.805060 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for parent at /mango-test/services
I, [2019-07-08T14:39:37.805194 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-test_8
I, [2019-07-08T14:39:37.806105 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for children at /mango-test/services
I, [2019-07-08T14:39:37.811649 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-test_8
I, [2019-07-08T14:39:37.811759 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-test_8 for service mango-test_8; keep existing config_for_generator: {"haproxy"=>{"server_options"=>"check port %{port} inter 30s do
wninter 1s rise 1 fall 2 ssl verify required ca-file /etc/internal_x509/securestack_ca_chain.pem crt /etc/internal_x509/securestack_client_private_bundle.pem", "server_port_override"=>nil, "backend"=>["option http-server-close"], "frontend"=>["acl use_local_backend nbsrv(
sssp-local-az) ge 3", "acl use_regional_backend nbsrv(sssp-regional) ge 3", "use_backend sssp-local-az if use_local_backend", "use_backend sssp-regional if use_regional_backend", "bind ::1:3526"], "listen"=>["mode http", "option tcp-check", "option httplog"]}}
I, [2019-07-08T14:39:37.811925 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test_9 @ cluster 127.0.0.1:2181 path: /mango-test/services
I, [2019-07-08T14:39:37.811953 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zookeeper watcher connecting to ZK at 127.0.0.1:2181
I, [2019-07-08T14:39:37.811974 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: re-using existing zookeeper connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.812020 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: retrieved zk connection to 127.0.0.1:2181
I, [2019-07-08T14:39:37.814796 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: register watch at /mango-test/services
I, [2019-07-08T14:39:37.815567 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for parent at /mango-test/services
I, [2019-07-08T14:39:37.815651 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-test_9
I, [2019-07-08T14:39:37.816079 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for children at /mango-test/services
I, [2019-07-08T14:39:37.820031 #40097]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-test_9
```

@austin-zhu @Jason-Jian @allenlsy @Ramyak 