### PR TITLE
Make schema fixed for backend info

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.17.0)
+    synapse (0.17.1)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -454,6 +454,6 @@ class Synapse::ServiceWatcher
         'labels' => node['labels']
       }
     end
-    end
-      end
+  end
+end
 

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -445,7 +445,7 @@ class Synapse::ServiceWatcher
     end
 
     def create_backend_info(id, node)
-      log.debug "synapse: discovered backend with child #{id} at #{node['name']} #{node['host']}:#{node['port']} for service #{@name}"
+      log.debug "synapse: discovered backend with child #{id} at #{node['host']}:#{node['port']} for service #{@name}"
       node['id'] = parse_numeric_id_suffix(id)
       return {
         'name' => node['name'], 'host' => node['host'], 'port' => node['port'],

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -383,9 +383,13 @@ class Synapse::ServiceWatcher
       log.debug "synapse: deserializing process data"
       decoded = @decode_method.call(data)
 
-      host = decoded['host'] || (raise KeyError, 'instance json data does not have host key')
-      port = decoded['port'] || (raise KeyError, 'instance json data does not have port key')
-      name = decoded['name'] || nil
+      unless decoded.key?('host')
+        raise KeyError, 'instance json data does not have host key'
+      end
+
+      unless decoded.key?('port')
+        raise KeyError, 'instance json data does not have port key'
+      end
 
       return decoded
     end
@@ -429,7 +433,7 @@ class Synapse::ServiceWatcher
         else
           if generator_config.nil? || !generator_config.is_a?(Hash)
             log.warn "synapse: invalid generator config in ZK node at #{@discovery['path']}" \
-            " for generator #{generator_name}"
+              " for generator #{generator_name}"
             new_generator_config[generator_name] = {}
           else
             new_generator_config[generator_name] = generator_config
@@ -450,6 +454,6 @@ class Synapse::ServiceWatcher
         'labels' => node['labels']
       }
     end
-  end
-end
+    end
+      end
 

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -186,7 +186,7 @@ class Synapse::ServiceWatcher
           if id.start_with?(CHILD_NAME_ENCODING_PREFIX)
             decoded = parse_base64_encoded_prefix(id)
             if decoded != nil
-              new_backends << get_backend(id, decoded)
+              new_backends << create_backend_info(id, decoded)
               next
             end
           end
@@ -214,7 +214,7 @@ class Synapse::ServiceWatcher
             log.error "synapse: skip child due to invalid data in ZK at #{@discovery['path']}/#{id}: #{e}"
             statsd_increment('synapse.watcher.zk.parse_child_failed')
           else
-            new_backends << get_backend(id, decoded)
+            new_backends << create_backend_info(id, decoded)
           end
         end
 
@@ -440,7 +440,7 @@ class Synapse::ServiceWatcher
       return new_generator_config
     end
 
-    def get_backend(id, node)
+    def create_backend_info(id, node)
       log.debug "synapse: discovered backend with child #{id} at #{node['name']} #{node['host']}:#{node['port']} for service #{@name}"
       node['id'] = parse_numeric_id_suffix(id)
       return {

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.17.0"
+  VERSION = "0.17.1"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -60,8 +60,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   end
   let(:service_data_string) { service_data.to_json }
   let(:deserialized_service_data) {
-    [ service_data['host'], service_data['port'], service_data['name'], service_data['weight'],
-      service_data['haproxy_server_options'], service_data['labels'] ]
+    service_data
   }
   let(:config_for_generator_string) { [config_for_generator.to_json] }
   let(:parsed_config_for_generator) do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -277,6 +277,31 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       it 'parse numeric id suffix returns nil' do
         expect(subject.send(:parse_numeric_id_suffix, "i-xxxxxxx_60da")).to be nil
       end
+
+      it 'parse backend returns correct data with fixed schema' do
+        node = {
+          'name' => 'i-xxxxxxx',
+          'host' => '127.0.0.1',
+          'port' => '3000',
+          'labels' => {
+            'region' => 'us-east-1',
+            'az' => 'us-east-1a'
+          }
+        }
+        backend = {
+          'name' => 'i-xxxxxxx',
+          'host' => '127.0.0.1',
+          'port' => '3000',
+          'labels' => {
+            'region' => 'us-east-1',
+            'az' => 'us-east-1a'
+          },
+          'weight' => nil,
+          'haproxy_server_options' => nil,
+          'id' => 5
+        }
+        expect(subject.send(:create_backend_info, "i-xxxxxxx_0000000005", node)).to eq backend
+      end
     end
   end
 


### PR DESCRIPTION
# Problem
During path encoding optimization rollout, we found synapse reloads haproxy more often even when list of backends did NOT change. 

# Root Cause
Synapse caches (in memory) the list of backends discovered last time and does a comparison against the list of backends newly discovered, and reload haproxy if there is a `change`. Before path encoding, the backend info include all fields even if they are nil, for example it could have `haproxy_server_options => nil`. After path encoding, the nil fields are not included, so `haproxy_server_options => nil` does not exist. This creates a false positive signal for haproxy reload, even though backends list and info do NOT change at all.

# Solution
Keep schema fixed, so all fields of backend info are kept and compared disregarding they are nil or not. This is to alleviate haproxy reload issue during path encoding rollout.

# Test
Run nerve with path encoding disabled
```
I, [2019-08-01T15:51:52.336733 #17097]  INFO -- Nerve::Nerve: nerve: launching new watchers: ["mango-test_26009_secure"]
D, [2019-08-01T15:51:52.336909 #17097] DEBUG -- Nerve::ServiceWatcher: nerve: creating service watcher object
D, [2019-08-01T15:51:52.383313 #17097] DEBUG -- Nerve::ServiceWatcher: nerve: created service watcher for mango-test_26009_secure with 2 checks
D, [2019-08-01T15:51:52.383367 #17097] DEBUG -- Nerve::Nerve: nerve: launching service watcher mango-test_26009_secure
```
Run synapse locally
```
D, [2019-08-01T15:52:42.811859 #17181] DEBUG -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered backend with child data at macbook-pro 127.0.0.1:6007 for service mango-test
I, [2019-08-01T15:52:42.811913 #17181]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-test
```


Run nerve with path encoding enabled
```
I, [2019-08-01T15:51:52.336733 #17097]  INFO -- Nerve::Nerve: nerve: launching new watchers: ["mango-test_26009_secure"]
D, [2019-08-01T15:51:52.336909 #17097] DEBUG -- Nerve::ServiceWatcher: nerve: creating service watcher object
D, [2019-08-01T15:51:52.383313 #17097] DEBUG -- Nerve::ServiceWatcher: nerve: created service watcher for mango-test_26009_secure with 2 checks
D, [2019-08-01T15:51:52.383367 #17097] DEBUG -- Nerve::Nerve: nerve: launching service watcher mango-test_26009_secure
```

Verify synapse detected backends had no change
```
D, [2019-08-01T15:54:24.160372 #17264] DEBUG -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for parent at /mango-test/services
I, [2019-08-01T15:54:24.160419 #17264]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-test
D, [2019-08-01T15:54:24.160834 #17264] DEBUG -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: set watch for children at /mango-test/services
I, [2019-08-01T15:54:24.160866 #17264]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: backends for service mango-test do not change.
I, [2019-08-01T15:54:24.160880 #17264]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-test for service mango-test; keep existing config_for_generator
```

tested in pre-production
```
I, [2019-08-02T16:49:50.803514 #11131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-canary for service mango-canary; keep existing config_for_generator
I, [2019-08-02T16:49:51.252600 #11131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-canary
I, [2019-08-02T16:49:51.253699 #11131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-canary
I, [2019-08-02T16:49:51.253742 #11131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-canary for service mango-canary; keep existing config_for_generator
I, [2019-08-02T16:49:51.774511 #11131]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2019-08-02T16:49:51.782018 #11131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: reconfigured haproxy via /var/haproxy/stats1.sock
```

# Reviewers
@austin-zhu @Jason-Jian @Ramyak 