### PR TITLE
Avoid creating parent path per zk session

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.17.2)
+    synapse (0.17.3)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -146,13 +146,6 @@ class Synapse::ServiceWatcher
       result
     end
 
-    # helper method that ensures that the discovery path exists
-    def create(path)
-      # recurse if the parent node does not exist
-      create File.dirname(path) unless @zk.exists? File.dirname(path)
-      @zk.create(path, ignore: :node_exists)
-    end
-
     # find the current backends at the discovery path
     def discover
       statsd_increment('synapse.watcher.zk.discovery', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"])
@@ -367,11 +360,14 @@ class Synapse::ServiceWatcher
         end
 
         # the path must exist, otherwise watch callbacks will not work
-        with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
-          statsd_time('synapse.watcher.zk.create_path.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
-            log.info "synapse: zk create at #{@discovery['path']} for #{attempts} times"
-            create(@discovery['path'])
-          end
+        existed = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
+            log.info "synapse: zk exists at #{@discovery['path']} for #{attempts} times"
+            exists(@discovery['path'])
+        end
+
+        unless existed
+          log.warn "synapse zk path #{@discovery['path']} does not exist, skip bootstrap"
+          return
         end
         # call the callback to bootstrap the process
         watcher_callback.call

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -362,7 +362,7 @@ class Synapse::ServiceWatcher
         # the path must exist, otherwise watch callbacks will not work
         existed = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
             log.info "synapse: zk exists at #{@discovery['path']} for #{attempts} times"
-            exists(@discovery['path'])
+            @zk.exists?(@discovery['path'])
         end
 
         unless existed

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.17.2"
+  VERSION = "0.17.3"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -180,9 +180,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         expect(ZK).to receive(:new).and_raise(RuntimeError)
         expect(ZK).to receive(:new).and_return(mock_zk)
         expect(mock_zk).to receive(:on_expired_session)
-        expect(mock_zk).to receive(:exists?).with('some').exactly(2).and_return(true)
-        expect(mock_zk).to receive(:create).with('some/path', {:ignore=>:node_exists}).once.and_raise(ZK::Exceptions::OperationTimeOut)
-        expect(mock_zk).to receive(:create).with('some/path', {:ignore=>:node_exists}).once.and_return(true)
+        expect(mock_zk).to receive(:exists?).with('some/path').and_return(true)
         expect(subject).to receive(:watch)
         expect(subject).to receive(:discover)
         subject.start
@@ -196,15 +194,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       it 'exists fails with retriable error retries until failed' do
         expect(ZK).to receive(:new).and_return(mock_zk)
         expect(mock_zk).to receive(:on_expired_session)
-        expect(mock_zk).to receive(:exists?).with('some').exactly(2).and_raise(ZK::Exceptions::OperationTimeOut)
-        expect { subject.start }.to raise_error(ZK::Exceptions::OperationTimeOut)
-      end
-
-      it 'create fails with retriable error retires until failed' do
-        expect(ZK).to receive(:new).and_return(mock_zk)
-        expect(mock_zk).to receive(:on_expired_session)
-        expect(mock_zk).to receive(:exists?).with('some').exactly(2).and_return(true)
-        expect(mock_zk).to receive(:create).with('some/path', {:ignore=>:node_exists}).exactly(2).and_raise(ZK::Exceptions::OperationTimeOut)
+        expect(mock_zk).to receive(:exists?).with('some/path').exactly(2).and_raise(ZK::Exceptions::OperationTimeOut)
         expect { subject.start }.to raise_error(ZK::Exceptions::OperationTimeOut)
       end
     end


### PR DESCRIPTION
# Problem
Synapse tries to create one znode per service path without checking its existence, this causes unnecessary zookeeper write and additional (error) transaction bump

The service path creation is already covered by the write side in status reporter like nerve:
https://github.com/airbnb/nerve/blob/f85ce262036a8233676a5b182449a777056da0df/lib/nerve/reporter/zookeeper.rb#L158

Synapse should be readonly, and it should not try to create service path. if the service path does not exist, it means the server side is not ready for discovery

# Solution

Replace service path `creation` with `existence check`, and skip registering watch if service path does not exist.

# Test
Before the fix:
```
10/4/19 1:57:20 PM PDT session 0x100055c9085002a cxid 0x0 zxid 0xaa createSession 20001

10/4/19 1:57:20 PM PDT session 0x100055c9085002a cxid 0x5d97b231 zxid 0xab error -110

10/4/19 1:57:21 PM PDT session 0x100055c9085002a cxid 0x5d97b234 zxid 0xac closeSession null
```

After the fix:
```
10/4/19 1:55:50 PM PDT session 0x100055c90850029 cxid 0x0 zxid 0xa8 createSession 20001

10/4/19 1:55:51 PM PDT session 0x100055c90850029 cxid 0x5d97b1d9 zxid 0xa9 closeSession null
```
# Reviewers
@panchr @Ramyak  @Jason-Jian 
