### PR TITLE
Emit version with ping metric

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.17.3)
+    synapse (0.17.4)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -6,7 +6,7 @@ require 'synapse/log'
 require 'synapse/statsd'
 require 'synapse/config_generator'
 require 'synapse/service_watcher'
-
+require 'synapse/version'
 
 module Synapse
   class Synapse
@@ -62,7 +62,7 @@ module Synapse
         loop do
           @service_watchers.each do |w|
             alive = w.ping?
-            statsd_increment('synapse.watcher.ping.count', ["watcher_name:#{w.name}", "ping_result:#{alive ? "success" : "failure"}"])
+            statsd_increment('synapse.watcher.ping.count', ["watcher_name:#{w.name}", "ping_result:#{alive ? "success" : "failure"}", "synapse_version:#{VERSION}"])
             raise "synapse: service watcher #{w.name} failed ping!" unless alive
           end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.17.3"
+  VERSION = "0.17.4"
 end


### PR DESCRIPTION
This adds metrics about the Synapse version per-ping. Tested by checking that metrics are properly emitted on a specific host.