### PR TITLE
Validate HAProxy config prior to writing config file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    synapse (0.17.4)
+    synapse (0.18.0)
       aws-sdk (~> 1.39)
       docker-api (~> 1.7)
       dogstatsd-ruby (~> 3.3.0)

--- a/README.md
+++ b/README.md
@@ -362,10 +362,13 @@ listen on 127.0.0.3:443) allows /etc/hosts entries to point to services.
 
 The top level `haproxy` section of the config file has the following options:
 
-* `reload_command`: the command Synapse will run to reload HAProxy
-* `config_file_path`: where Synapse will write the HAProxy config file
-* `do_writes`: whether or not the config file will be written (default to `true`)
+* `do_checks`: whether or not Synapse will validate HAProxy config prior to writing it (default to `false`)
+* `check_command`: the command Synapse will run to validate HAProxy config
+* `candidate_config_file_path`: the path to write the pre-validated (candidate) HAProxy config to for the check command
 * `do_reloads`: whether or not Synapse will reload HAProxy (default to `true`)
+* `reload_command`: the command Synapse will run to reload HAProxy
+* `do_writes`: whether or not the config file will be written (default to `true`)
+* `config_file_path`: where Synapse will write the HAProxy config file
 * `do_socket`: whether or not Synapse will use the HAProxy socket commands to prevent reloads (default to `true`)
 * `socket_file_path`: where to find the haproxy stats socket. can be a list (if using `nbproc`)
 * `global`: options listed here will be written into the `global` section of the HAProxy config

--- a/config/synapse.conf.json
+++ b/config/synapse.conf.json
@@ -54,6 +54,8 @@
   },
   "haproxy": {
     "reload_command": "sudo service haproxy reload",
+    "check_command": "haproxy -c -f /etc/haproxy/haproxy-candidate.cfg",
+    "candidate_config_file_path": "/etc/haproxy/haproxy-candidate.cfg",
     "config_file_path": "/etc/haproxy/haproxy.cfg",
     "socket_file_path": "/var/haproxy/stats.sock",
     "do_writes": false,

--- a/config/synapse.conf.json
+++ b/config/synapse.conf.json
@@ -53,15 +53,15 @@
     }
   },
   "haproxy": {
-    "reload_command": "sudo service haproxy reload",
-    "check_command": "haproxy -c -f /etc/haproxy/haproxy-candidate.cfg",
-    "candidate_config_file_path": "/etc/haproxy/haproxy-candidate.cfg",
-    "config_file_path": "/etc/haproxy/haproxy.cfg",
-    "socket_file_path": "/var/haproxy/stats.sock",
-    "do_writes": false,
     "do_checks": false,
+    "candidate_config_file_path": "/etc/haproxy/haproxy-candidate.cfg",
+    "check_command": "haproxy -c -f /etc/haproxy/haproxy-candidate.cfg",
     "do_reloads": false,
+    "reload_command": "sudo service haproxy reload",
+    "do_writes": false,
+    "config_file_path": "/etc/haproxy/haproxy.cfg",
     "do_socket": false,
+    "socket_file_path": "/var/haproxy/stats.sock",
     "global": [
       "daemon",
       "user haproxy",

--- a/config/synapse.conf.json
+++ b/config/synapse.conf.json
@@ -59,6 +59,7 @@
     "config_file_path": "/etc/haproxy/haproxy.cfg",
     "socket_file_path": "/var/haproxy/stats.sock",
     "do_writes": false,
+    "do_checks": false,
     "do_reloads": false,
     "do_socket": false,
     "global": [

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1345,10 +1345,12 @@ class Synapse::ConfigGenerator
       res, exit_code = Open3.capture2e(opts['check_command'])
       success = exit_code.success?
       unless success
-        log.error "invalid generated HAProxy config (checked via #{opts['check_command']}): #{res}"
+        log.error "synapse: invalid generated HAProxy config (checked via #{opts['check_command']}): #{res};\nexited with #{exit_code.exitstatus}"
       end
 
       statsd_increment("synapse.haproxy.check_config", ["success:#{success}"])
+      log.info "synapse: checked HAProxy config located at #{opts['candidate_config_file_path']}; status: #{success}"
+
       return success
     end
 

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -1342,13 +1342,16 @@ class Synapse::ConfigGenerator
         return true
       end
 
+      # capture2e runs a shell command and captures both stdout/stderr streams.
+      # It returns the combined streams (res) and the exit code (exit_code).
+      # See: https://docs.ruby-lang.org/en/2.0.0/Open3.html#method-i-capture2e.
       res, exit_code = Open3.capture2e(opts['check_command'])
       success = exit_code.success?
       unless success
-        log.error "synapse: invalid generated HAProxy config (checked via #{opts['check_command']}): #{res};\nexited with #{exit_code.exitstatus}"
+        log.error "synapse: invalid generated HAProxy config (checked via #{opts['check_command']}): exited with #{exit_code.exitstatus}: #{res}"
       end
 
-      statsd_increment("synapse.haproxy.check_config", ["success:#{success}"])
+      statsd_increment("synapse.haproxy.check_config", ["status:#{success}"])
       log.info "synapse: checked HAProxy config located at #{opts['candidate_config_file_path']}; status: #{success}"
 
       return success

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.17.4"
+  VERSION = "0.18.0"
 end

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -254,14 +254,16 @@ describe Synapse::ConfigGenerator::Haproxy do
       req_pairs = {
         'do_writes' => 'config_file_path',
         'do_socket' => 'socket_file_path',
-        'do_reloads' => 'reload_command'
+        'do_reloads' => 'reload_command',
+        'do_checks' => 'check_command',
       }
       valid_conf = {
         'global' => [],
         'defaults' => [],
         'do_reloads' => false,
         'do_socket' => false,
-        'do_writes' => false
+        'do_writes' => false,
+        'do_checks' => false,
       }
 
       req_pairs.each do |key, value|
@@ -273,7 +275,7 @@ describe Synapse::ConfigGenerator::Haproxy do
 
     end
 
-    it 'properly defaults do_writes, do_socket, do_reloads, use_nerve_weights' do
+    it 'properly defaults do_writes, do_socket, do_checks, do_reloads, use_nerve_weights' do
       conf = {
         'global' => [],
         'defaults' => [],
@@ -287,6 +289,7 @@ describe Synapse::ConfigGenerator::Haproxy do
       expect(haproxy.opts['do_writes']).to eql(true)
       expect(haproxy.opts['do_socket']).to eql(true)
       expect(haproxy.opts['do_reloads']).to eql(true)
+      expect(haproxy.opts['do_checks']).to eql(false)
       expect(haproxy.opts['use_nerve_weights']).to eql(nil)
     end
 
@@ -408,7 +411,10 @@ describe Synapse::ConfigGenerator::Haproxy do
 
     context 'if we support config writes' do
       include_context 'generate_config is stubbed out'
-      before { config['haproxy']['do_writes'] = true }
+      before {
+        config['haproxy']['do_writes'] = true
+        config['haproxy']['do_checks'] = false
+      }
 
       it 'writes the new config' do
         expect(subject).to receive(:write_config).with(new_config)
@@ -778,7 +784,61 @@ describe Synapse::ConfigGenerator::Haproxy do
     end
   end
 
+  describe '#check_config?' do
+    let(:exit_success) { double }
+    let(:exit_fail) { double }
 
+    before {
+      allow(exit_success).to receive(:success?).and_return(true)
+      allow(exit_success).to receive(:exitstatus).and_return(0)
+
+      allow(exit_fail).to receive(:success?).and_return(false)
+      allow(exit_fail).to receive(:exitstatus).and_return(1)
+
+      config['haproxy']['do_checks'] = true
+      config['haproxy']['check_command'] = 'haproxy_check_mock'
+    }
+
+    it 'calls the supplied command' do
+      expect(Open3).to receive(:capture2e).with("haproxy_check_mock").and_return(["success", exit_success])
+      subject.check_config?
+    end
+
+    context 'when check command succeeds' do
+      before {
+        expect(Open3).to receive(:capture2e).and_return(["haproxy check succeeded", exit_success])
+      }
+
+      it 'returns true' do
+        expect(subject.check_config?).to eq(true)
+      end
+    end
+
+    context 'when check command fails' do
+      before {
+        expect(Open3).to receive(:capture2e).and_return(["haproxy check failed", exit_fail])
+      }
+
+      it 'returns true' do
+        expect(subject.check_config?).to eq(false)
+      end
+    end
+
+    context 'when do_checks is false' do
+      before {
+        config['haproxy']['do_checks'] = false
+      }
+
+      it 'always returns true' do
+        expect(subject.check_config?).to eq(true)
+      end
+
+      it 'does not call command' do
+        expect(Open3).not_to receive(:capture2e)
+        subject.check_config?
+      end
+    end
+  end
 
   it 'generates frontend stanza ' do
     mockConfig = []

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -784,6 +784,92 @@ describe Synapse::ConfigGenerator::Haproxy do
     end
   end
 
+  describe '#write_config' do
+    before {
+      config['haproxy']['config_file_path'] = 'config_file'
+      config['haproxy']['candidate_config_file_path'] = 'candidate_config_file'
+
+      allow(File).to receive(:read).with('config_file').and_return('haproxy-config')
+      allow(File).to receive(:read).with('candidate_config_file').and_return('candidate-haproxy-config')
+    }
+
+    context 'when config changes' do
+      it 'writes candidate config' do
+        allow(FileUtils).to receive(:mv)
+        allow(subject).to receive(:check_config?).and_return(true)
+
+        expect(File).to receive(:write).with('candidate_config_file', 'new-config')
+        subject.write_config('new-config')
+      end
+
+      it 'checks config command' do
+        allow(FileUtils).to receive(:mv)
+        allow(File).to receive(:write).with('candidate_config_file', 'new-config')
+
+        expect(subject).to receive(:check_config?).and_return(true)
+        subject.write_config('new-config')
+      end
+
+      context 'when config file does not exist' do
+        before {
+          allow(File).to receive(:read).with('config_file').and_raise(Errno::ENOENT)
+          allow(subject).to receive(:check_config?).and_return(true)
+        }
+
+        it 'writes the new config' do
+          expect(File).to receive(:write).with('candidate_config_file', 'haproxy-config')
+          expect(FileUtils).to receive(:mv).with('candidate_config_file', 'config_file')
+          expect(subject.write_config('haproxy-config')).to eq(true)
+        end
+      end
+
+      context 'when config check succeeds' do
+        before {
+          expect(subject).to receive(:check_config?).and_return(true)
+        }
+
+        it 'moves the candidate file to normal location' do
+          allow(File).to receive(:write).with('candidate_config_file', 'new-config')
+          expect(FileUtils).to receive(:mv).with('candidate_config_file', 'config_file')
+          expect(subject.write_config('new-config')).to eq(true)
+        end
+      end
+
+      context 'when config check fails' do
+        before {
+          expect(subject).to receive(:check_config?).and_return(false)
+          allow(File).to receive(:write).with('candidate_config_file', 'new-config')
+        }
+
+        it 'does not move the candidate file to production location' do
+          expect(FileUtils).not_to receive(:mv)
+          expect(subject.write_config('new-config')).to eq(false)
+        end
+      end
+    end
+
+    context 'when config does not change' do
+      it 'returns false' do
+        expect(subject.write_config('haproxy-config')).to eq(false)
+      end
+
+      it 'does not write the candidate config' do
+        expect(File).not_to receive(:write)
+        subject.write_config('haproxy-config')
+      end
+
+      it 'does not move the candidate file' do
+        expect(FileUtils).not_to receive(:mv)
+        subject.write_config('haproxy-config')
+      end
+
+      it 'does not check config command' do
+        expect(subject).not_to receive(:check_config?)
+        subject.write_config('haproxy-config')
+      end
+    end
+  end
+
   describe '#check_config?' do
     let(:exit_success) { double }
     let(:exit_fail) { double }


### PR DESCRIPTION
This PR adds the following:

* capability for Synapse to run a custom command to validate HAProxy config prior to writing the config file (config is held in a "staging" file before that)
    - *Note:* this does not affect reloading, just writing the config. HAProxy will still get restarted, but it will continue to use good config.
   - The goal is that the "production" config file (i.e. that used by the `HAProxy` process) will always be valid.
* configuration for HAProxy validation
* unit tests for those additions

Because of state file caching, it is still possible that certain bad state will remain in Synapse (in-memory and in cache file). However, that state will not propagate to HAProxy; HAProxy will remain with the last good state.

## Tests
### 1. Local Testing of bad haproxy config in ZK
Synapse does not write bad HAProxy config:
```
I, [2020-01-16T15:58:57.760357 #79492]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-test for service mango-test; keep existing config_for_generator
I, [2020-01-16T15:58:58.237389 #79492]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-01-16T15:58:58.238499 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: @watcher config: {"mango-test"=>{"frontend"=>["mode http"], "backend"=>["mode http", "option httpchk /health", "http-check expect string OK"]}}
I, [2020-01-16T15:58:58.238539 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: @frontends_cache: {"mango-test"=>["\nfrontend mango-test", ["\tmode http"], "\tbind localhost:3213 ", "\tdefault_backend mango-test"]}
I, [2020-01-16T15:58:58.238569 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: @backends_cache: {"mango-test"=>["\nbackend mango-test", ["\tmode http", "\toption httpchk /health", "\thttp-check expect string OK"], ["\tserver i-{HOST1} {IP1} cookie i-{HOST1} check inter 2s rise 3 fall 2 id 1", "\tserver i-{HOST2} {IP2} cookie i-{HOST2} check inter 2s rise 3 fall 2 id 1"]]}
I, [2020-01-16T15:58:58.238619 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: @watcher_revisions: {"mango-test"=>2}
E, [2020-01-16T15:58:58.245069 #79492] ERROR -- Synapse::ConfigGenerator::Haproxy: synapse: invalid generated HAProxy config (checked via haproxy -c -f /usr/local/etc/haproxy/haproxy-staging.cfg): [ALERT] 015/155858 (80168) : parsing [/usr/local/etc/haproxy/haproxy-staging.cfg:29] : 'server i-{HOST}' : 'id' : custom id 1 already used at /usr/local/etc/haproxy/haproxy-staging.cfg:28 ('server i-{HOST}')
[ALERT] 015/155858 (80168) : Error(s) found in configuration file : /usr/local/etc/haproxy/haproxy-staging.cfg
[ALERT] 015/155858 (80168) : Fatal errors found in configuration.

I, [2020-01-16T15:58:58.245358 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: checked HAProxy config located at /usr/local/etc/haproxy/haproxy-staging.cfg; status: false
I, [2020-01-16T15:58:58.245397 #79492]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: at time 21 waiting until 39 to restart
```

Running HAProxy config is still valid, while "staging" is invalid:
```
$ haproxy -c -f /usr/local/etc/haproxy/haproxy.cfg
Configuration file is valid

$ haproxy -c -f /usr/local/etc/haproxy/haproxy-staging.cfg
[ALERT] 015/160311 (88063) : parsing [/usr/local/etc/haproxy/haproxy-staging.cfg:29] : 'server i-{HOST}' : 'id' : custom id 1 already used at /usr/local/etc/haproxy/haproxy-staging.cfg:28 ('server i-{HOST}')
[ALERT] 015/160311 (88063) : Error(s) found in configuration file : /usr/local/etc/haproxy/haproxy-staging.cfg
[ALERT] 015/160311 (88063) : Fatal errors found in configuration.
```

### 2. Normal behavior: HAProxy configuration is valid (`mango-test`)
```
I, [2020-01-17T00:23:40.639575 #5450]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zk exists at /production/secure/services/mango-canary/services for 1 times
I, [2020-01-17T00:23:40.640891 #5450]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service mango-canary
I, [2020-01-17T00:23:40.640984 #5450]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zk list children at /production/secure/services/mango-canary/services for 1 times
I, [2020-01-17T00:23:40.644566 #5450]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 2 backends for service mango-canary
I, [2020-01-17T00:23:40.644614 #5450]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-canary for service mango-canary; keep existing config_for_generator
I, [2020-01-17T00:23:41.462955 #5450]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-01-17T00:23:41.467110 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because we have a new backend mango-canary/i-{HOST}
I, [2020-01-17T00:23:41.467710 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: reconfigured haproxy via /var/haproxy/stats1.sock
I, [2020-01-17T00:23:41.530083 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: checked HAProxy config located at /etc/haproxy/haproxy-staging.cfg; status: true
I, [2020-01-17T00:23:41.634800 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restarted haproxy
```

### 3. Behavior with invalid haproxy config (`mango-test`)
```
I, [2020-01-17T00:31:22.976560 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because we have a new backend mango-canary/i-badconfig_randomip:2048
I, [2020-01-17T00:31:22.977113 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: reconfigured haproxy via /var/haproxy/stats1.sock
I, [2020-01-17T00:31:22.982254 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because haproxy_server_options changed for i-{HOST}
E, [2020-01-17T00:31:23.071370 #5450] ERROR -- Synapse::ConfigGenerator::Haproxy: synapse: invalid generated HAProxy config (checked via sudo haproxy -c -f /etc/haproxy/haproxy-staging.cfg): [ALERT] 016/003122 (6935) : parsing [/etc/haproxy/haproxy-staging.cfg:286] : 'server i-badconfig_randomip:2048' : invalid address: 'randomip' in 'randomip:2048'

[ALERT] 016/003122 (6935) : parsing [/etc/haproxy/haproxy-staging.cfg:288] : 'server i-{HOST}' : 'id' : custom id 1 already used at /etc/haproxy/haproxy-staging.cfg:287 ('server i-{HOST}')
[ALERT] 016/003122 (6935) : Error(s) found in configuration file : /etc/haproxy/haproxy-staging.cfg
[ALERT] 016/003123 (6935) : Fatal errors found in configuration.

I, [2020-01-17T00:31:23.071532 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: checked HAProxy config located at /etc/haproxy/haproxy-staging.cfg; status: false
I, [2020-01-17T00:31:23.177268 #5450]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restarted haproxy
```

Running HAProxy config is valid because it is unchanged:
```
$ sudo haproxy -c -f /etc/haproxy/haproxy.cfg
Configuration file is valid

$ sudo haproxy -c -f /etc/haproxy/haproxy-staging.cfg
[ALERT] 016/003421 (7404) : parsing [/etc/haproxy/haproxy-staging.cfg:286] : 'server i-badconfig_randomip:2048' : invalid address: 'randomip' in 'randomip:2048'

[ALERT] 016/003421 (7404) : parsing [/etc/haproxy/haproxy-staging.cfg:288] : 'server i-{HOST}' : 'id' : custom id 1 already used at /etc/haproxy/haproxy-staging.cfg:287 ('server i-{HOST}')
[ALERT] 016/003421 (7404) : Error(s) found in configuration file : /etc/haproxy/haproxy-staging.cfg
[ALERT] 016/003421 (7404) : Fatal errors found in configuration.

 $ sudo service haproxy status
haproxy is running.
```

### 4. `do_checks = false` behavior with valid haproxy config
No check is performed:
```
I, [2020-01-17T01:05:25.729172 #12131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zk list children at /production/secure/services/mango-canary/services for 1 times
I, [2020-01-17T01:05:25.730542 #12131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service mango-canary
I, [2020-01-17T01:05:25.730588 #12131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-canary for service mango-canary; keep existing config_for_generator
I, [2020-01-17T01:05:26.664936 #12131]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-01-17T01:05:26.669463 #12131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because we added new section mango-canary
I, [2020-01-17T01:05:26.670212 #12131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: reconfigured haproxy via /var/haproxy/stats1.sock
I, [2020-01-17T01:05:26.788794 #12131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restarted haproxy
```

### 5. `do_checks = False` behavior with *invalid* haproxy config
No check is performed, but HAProxy will fail to restart:
```
I, [2020-01-17T01:07:23.061730 #12131]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from mango-canary for service mango-canary; keep existing config_for_generator
I, [2020-01-17T01:07:23.884589 #12131]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-01-17T01:07:23.887874 #12131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because we have a new backend mango-canary/i-myhost2_1.1.1.2:1026
I, [2020-01-17T01:07:23.888533 #12131]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: reconfigured haproxy via /var/haproxy/stats1.sock
[ALERT] 016/010723 (12829) : parsing [/etc/haproxy/haproxy.cfg:287] : 'server i-myhost2_1.1.1.2:1026' : 'id' : custom id 1 already used at /etc/haproxy/haproxy.cfg:286 ('server i-myhost_1.1.1.1:1025')
[ALERT] 016/010723 (12829) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
[ALERT] 016/010723 (12829) : Fatal errors found in configuration.
E, [2020-01-17T01:07:23.959745 #12131] ERROR -- Synapse::ConfigGenerator::Haproxy: failed to reload haproxy via sudo service haproxy reload:  * Reloading haproxy haproxy
   ...fail!
```

And the "production" config is invalid:
```
 $ sudo haproxy -c -f /etc/haproxy/haproxy.cfg
[ALERT] 016/010751 (12902) : parsing [/etc/haproxy/haproxy.cfg:287] : 'server i-myhost2_1.1.1.2:1026' : 'id' : custom id 1 already used at /etc/haproxy/haproxy.cfg:286 ('server i-myhost_1.1.1.1:1025')
[ALERT] 016/010751 (12902) : Error(s) found in configuration file : /etc/haproxy/haproxy.cfg
[ALERT] 016/010751 (12902) : Fatal errors found in configuration.
```

## Reviewers
@anson627 @austin-zhu @Jason-Jian 
cc: @Ramyak