### PR TITLE
Ensure that haproxy check parameters are set together

### DIFF
--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -816,16 +816,18 @@ class Synapse::ConfigGenerator
       @opts['do_socket'] = true unless @opts.key?('do_socket')
       @opts['do_checks'] = false unless @opts.key?('do_checks')
       @opts['do_reloads'] = true unless @opts.key?('do_reloads')
-      req_pairs = {
-        'do_writes' => 'config_file_path',
-        'do_socket' => 'socket_file_path',
-        'do_checks' => 'check_command',
-        'do_reloads' => 'reload_command'
+      req_groups = {
+        'do_writes' => ['config_file_path'],
+        'do_socket' => ['socket_file_path'],
+        'do_checks' => ['check_command', 'candidate_config_file_path'],
+        'do_reloads' => ['reload_command'],
       }
 
-      req_pairs.each do |cond, req|
-        if @opts[cond]
-          raise ArgumentError, "the `#{req}` option is required when `#{cond}` is true" unless @opts[req]
+      req_groups.each do |cond, reqs|
+        reqs.each do |req_config|
+          if @opts[cond]
+            raise ArgumentError, "the `#{req_config}` option is required when `#{cond}` is true" unless @opts[req_config]
+          end
         end
       end
 

--- a/lib/synapse/config_generator/haproxy.rb
+++ b/lib/synapse/config_generator/haproxy.rb
@@ -831,6 +831,9 @@ class Synapse::ConfigGenerator
         end
       end
 
+      # Default candidate_config_file_path so that write_config can do atomic writes.
+      @opts['candidate_config_file_path'] = "#{@opts['config_file_path']}.tmp" unless @opts.key?('candidate_config_file_path')
+
       # socket_file_path can be a string or a list
       # lets make a new option which is always a list (plural)
       @opts['socket_file_paths'] = [@opts['socket_file_path']].flatten

--- a/spec/lib/synapse/haproxy_spec.rb
+++ b/spec/lib/synapse/haproxy_spec.rb
@@ -833,6 +833,20 @@ describe Synapse::ConfigGenerator::Haproxy do
       allow(File).to receive(:read).with('candidate_config_file').and_return('candidate-haproxy-config')
     }
 
+    context 'when candidate_config_file_path is not set' do
+      before {
+        config['haproxy'].delete('candidate_config_file_path')
+        config['haproxy']['do_checks'] = false
+      }
+
+      it 'still succeeds' do
+        allow(FileUtils).to receive(:mv)
+
+        expect(File).to receive(:write).with('config_file.tmp', 'new-config')
+        expect{subject.write_config('new-config')}.not_to raise_error
+      end
+    end
+
     context 'when config changes' do
       it 'writes candidate config' do
         allow(FileUtils).to receive(:mv)


### PR DESCRIPTION
## Summary

Currently, Synapse already crashes when all the required haproxy check parameters (`do_checks`, `candidate_config_file_path`, and `check_command`) are not set together. However, this crash does not have any meaningful information.

This PR validates that the configuration is all set together and if not, raises an error with a useful message (similar to other config checks already performed).

## Testing
### 1. Unit tests
### 2. Without config set:
`candidate_config_file_path` missing:
```
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-haproxy-validation.json
I, [2020-01-24T11:04:22.339294 #48364]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
/.../synapse/lib/synapse/config_generator/haproxy.rb:829:in `block (2 levels) in initialize': the `candidate_config_file_path` option is required when `do_checks` is true (ArgumentError)
...
```

`check_command` missing:
```
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-haproxy-validation.json
I, [2020-01-24T11:05:12.839824 #49966]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
/.../synapse/lib/synapse/config_generator/haproxy.rb:829:in `block (2 levels) in initialize': the `check_command` option is required when `do_checks` is true (ArgumentError
...
```

### 3. With config set:

```
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-haproxy-validation.json
I, [2020-01-24T11:05:46.744284 #51039]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
I, [2020-01-24T11:05:46.797344 #51039]  INFO -- Synapse::Synapse: synapse: starting...
I, [2020-01-24T11:05:46.799448 #51039]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test @ cluster: localhost: path: /production/secure/services/mango-test/services retry policy: {"max_attempts"=>10, "max_delay"=>600, "base_interval"=>0.5, "max_interval"=>60}
```

### 4. `do_checks = false`, check config not set
```
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-haproxy-validation.json
I, [2020-01-24T11:36:30.199076 #10084]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
I, [2020-01-24T11:36:30.254298 #10084]  INFO -- Synapse::Synapse: synapse: starting...
I, [2020-01-24T11:36:30.256854 #10084]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test @ cluster: localhost: path: /production/secure/services/mango-test/services retry policy: {"max_attempts"=>10, "max_delay"=>600, "base_interval"=>0.5, "max_interval"=>60}
```

### 5. `do_checks = false`, check config set
```
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-haproxy-validation.json
I, [2020-01-24T11:37:37.306066 #12338]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
I, [2020-01-24T11:37:37.364017 #12338]  INFO -- Synapse::Synapse: synapse: starting...
I, [2020-01-24T11:37:37.366103 #12338]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: starting ZK watcher mango-test @ cluster: localhost: path: /production/secure/services/mango-test/services retry policy: {"max_attempts"=>10, "max_delay"=>600, "base_interval"=>0.5, "max_interval"=>60}
```

## Reviewers
@anson627 