### PR TITLE
Add simplecov and simplecov-json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
+    docile (1.3.2)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
@@ -35,7 +36,6 @@ GEM
     excon (0.62.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
-    ffi (1.9.10)
     ffi (1.9.10-java)
     hashdiff (0.2.3)
     i18n (0.7.0)
@@ -77,6 +77,14 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
     safe_yaml (1.0.4)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    simplecov-json (0.2)
+      json
+      simplecov
     slop (3.6.0)
     slyphon-log4j (1.2.15)
     slyphon-zookeeper_jar (3.3.5-java)
@@ -108,6 +116,8 @@ DEPENDENCIES
   pry-nav
   rake
   rspec (~> 3.1.0)
+  simplecov (~> 0.16)
+  simplecov-json (~> 0.2)
   synapse!
   timecop
   webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,25 @@
 # loaded once.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+if ENV["CODE_COVERAGE"] == "true"
+  # SimpleCov must be started before anything else is loaded.
+  require "simplecov"
+  require "simplecov-json"
+
+  SimpleCov.start do
+    # Any not-loaded files matching this glob will be counted as having 0% coverage.
+    track_files "lib/**/*.rb"
+
+    # SimpleCov won't track coverage in files whose paths match these strings.
+    add_filter [
+      "/spec/",
+      "/version.rb", # Loads in advance with `bundle exec`.
+    ]
+
+    formatter SimpleCov::Formatter::JSONFormatter
+  end
+end
+
 require "#{File.dirname(__FILE__)}/../lib/synapse"
 require 'pry'
 require 'support/configuration'

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "webmock"
   gem.add_development_dependency "timecop"
+  gem.add_development_dependency "simplecov", "~> 0.16"
+  gem.add_development_dependency "simplecov-json", "~> 0.2"
 end


### PR DESCRIPTION
#### Summary
This change adds simplecov and simplecov-json to report code coverage.
To get code coverage information in your build you need to set the
CODE_COVERAGE env var to "true"

#### Test Plan
- [X] bundle exec rspec

#### Reviewers
@panchr