### PR TITLE
[WIP] Add MultiWatcher for watching multiple sources

### DIFF
--- a/config/discovery-multi.conf.json
+++ b/config/discovery-multi.conf.json
@@ -1,0 +1,93 @@
+{
+  "services": {
+    "service1": {
+      "discovery": {
+	"method": "zookeeper",
+	"path": "/services/service1",
+	"discovery_jitter": 25,
+	"hosts": [
+	  "localhost:2181",
+	  "localhost:2182",
+	  "localhost:2183"
+	]
+      },
+      "discovery_multi": {
+	"resolver": {
+	  "method": "fallback"
+	},
+	"watchers": {
+	  "secondary": {
+	    "method": "zookeeper",
+	    "path": "/services/service1",
+	    "discovery_jitter": 5,
+	    "hosts": [
+	      "localhost:2184",
+	      "localhost:2185",
+	      "localhost:2186"
+	    ]
+	  }
+	}
+      },
+      "haproxy": {
+	"port": 3213,
+	"server_options": "check inter 2s rise 3 fall 2",
+	"bind_options": "ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305",
+	"listen": [
+	  "mode http",
+	  "option httpchk /health",
+	  "http-check expect string OK"
+	]
+      }
+    }
+  },
+  "haproxy": {
+    "do_checks": false,
+    "candidate_config_file_path": "/etc/haproxy/haproxy-candidate.cfg",
+    "check_command": "haproxy -c -f /etc/haproxy/haproxy-candidate.cfg",
+    "do_reloads": false,
+    "reload_command": "sudo service haproxy reload",
+    "do_writes": false,
+    "config_file_path": "/etc/haproxy/haproxy.cfg",
+    "do_socket": false,
+    "socket_file_path": "/var/haproxy/stats.sock",
+    "global": [
+      "daemon",
+      "user haproxy",
+      "group haproxy",
+      "maxconn 4096",
+      "log     127.0.0.1 local0",
+      "log     127.0.0.1 local1 notice",
+      "stats   socket /var/haproxy/stats.sock mode 666 level admin"
+    ],
+    "defaults": [
+      "log      global",
+      "option   dontlognull",
+      "maxconn  2000",
+      "retries  3",
+      "timeout  connect 5s",
+      "timeout  client  1m",
+      "timeout  server  1m",
+      "option   redispatch",
+      "balance  roundrobin"
+    ],
+    "extra_sections": {
+      "listen stats :3212": [
+	"mode http",
+	"stats enable",
+	"stats uri /",
+	"stats refresh 5s"
+      ]
+    }
+  },
+  "statsd": {
+    "host": "localhost",
+    "port": 8125,
+    "sample_rate": {
+      "synapse.watcher.ping.count": 0.1,
+      "synapse.watcher.zk.discovery": 0.7,
+      "synapse.watcher.zk.discovery.elapsed_time": 0.7,
+      "synapse.watcher.zk.get.elapsed_time": 0.5,
+      "synapse.watcher.zk.watch.elapsed_time": 0.7
+    }
+  }
+}

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -11,15 +11,20 @@ module Synapse
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
+      return self.load_watcher(discovery_method, opts, synapse)
+    end
+
+    def self.load_watcher(discovery_method, opts, synapse)
       watcher = begin
-        method = discovery_method.downcase
-        require "synapse/service_watcher/#{method}"
-        # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
-        method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
-        self.const_get("#{method_class}")
-      rescue Exception => e
-        raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
-      end
+                  method = discovery_method.downcase
+                  require "synapse/service_watcher/#{method}"
+                  # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
+                  method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
+                  self.const_get("#{method_class}")
+                rescue Exception => e
+                  raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
+                end
+
       return watcher.new(opts, synapse)
     end
   end

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -1,10 +1,12 @@
 require "synapse/log"
 require "synapse/service_watcher/base"
+require "synapse/service_watcher/multi"
 
 module Synapse
   class ServiceWatcher
     # the method which actually dispatches watcher creation requests
     def self.create(name, opts, reconfigure_callback = nil, synapse)
+      opts = self.resolve_multi_config(opts)
       opts['name'] = name
 
       raise ArgumentError, "Missing discovery method when trying to create watcher" \
@@ -26,6 +28,16 @@ module Synapse
                 end
 
       return watcher.new(opts, reconfigure_callback, synapse)
+    end
+
+    private
+    def self.resolve_multi_config(opts)
+      if opts.has_key?('discovery_multi')
+        multi = opts.delete('discovery_multi')
+        opts['discovery'] = MultiWatcher.merge_discovery(multi, opts['discovery'])
+      end
+
+      return opts
     end
   end
 end

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,17 +4,17 @@ require "synapse/service_watcher/base"
 module Synapse
   class ServiceWatcher
     # the method which actually dispatches watcher creation requests
-    def self.create(name, opts, synapse)
+    def self.create(name, opts, reconfigure_callback = nil, synapse)
       opts['name'] = name
 
       raise ArgumentError, "Missing discovery method when trying to create watcher" \
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
-      return self.load_watcher(discovery_method, opts, synapse)
+      return self.load_watcher(discovery_method, opts, reconfigure_callback, synapse)
     end
 
-    def self.load_watcher(discovery_method, opts, synapse)
+    def self.load_watcher(discovery_method, opts, reconfigure_callback = nil, synapse)
       watcher = begin
                   method = discovery_method.downcase
                   require "synapse/service_watcher/#{method}"
@@ -25,7 +25,7 @@ module Synapse
                   raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
                 end
 
-      return watcher.new(opts, synapse)
+      return watcher.new(opts, reconfigure_callback, synapse)
     end
   end
 end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -14,11 +14,16 @@ class Synapse::ServiceWatcher
 
     attr_reader :name, :revision
 
-    def initialize(opts={}, synapse)
+    def initialize(opts={}, reconfigure_callback=nil, synapse)
       super()
 
       @synapse = synapse
       @revision = 0
+      @reconfigure_callback = if reconfigure_callback.nil?
+                                lambda { synapse.reconfigure! }
+                              else
+                                reconfigure_callback
+                              end
 
       # set required service parameters
       %w{name discovery}.each do |req|
@@ -241,7 +246,7 @@ class Synapse::ServiceWatcher
     # can be overridden in subclasses.
     def reconfigure!
       @revision += 1
-      @synapse.reconfigure!
+      @reconfigure_callback.call
     end
   end
 end

--- a/lib/synapse/service_watcher/multi.rb
+++ b/lib/synapse/service_watcher/multi.rb
@@ -1,0 +1,68 @@
+require "synapse/service_watcher/base"
+
+class Synapse::ServiceWatcher
+  # MultiWatcher allows using multiple watchers to obtain service discovery data
+  # with a configurable resolution strategy among them.
+  #
+  # Discovery options:
+  #   method => 'multi'
+  #   watchers => hash. Maps name => discovery hash. Discovery hash must include
+  #     method, and be of the same format as the method type expects.
+  #     (That is, method => zookeeper means a Zookeeper watcher will be created, so
+  #     the rest of the options will be passed to the ZookeeperWatcher class).
+  class MultiWatcher < BaseWatcher
+    def initialize(opts={}, reconfigure_callback=nil, synapse)
+      super(opts, reconfigure_callback, synapse)
+
+      @watchers = {}
+
+      watcher_config = @discovery['watchers'] || {}
+
+      watcher_config.each do |name, config|
+        # Merge (deep-cloned) top-level config with the discovery configuration.
+        merged_config = Marshal.load(Marshal.dump(opts))
+        merged_config['discovery'] = config
+
+        unless config.has_key?('method')
+          raise ArgumentError, "Discovery method not included in config for watcher #{name}"
+        end
+
+        discovery_method = config['method']
+        watcher = Synapse::ServiceWatcher.load_watcher(discovery_method, merged_config, synapse)
+
+        @watchers[name] = watcher
+      end
+    end
+
+    def start
+      log.info "synapse: starting multi watcher"
+
+      @watchers.values.each do |w|
+        w.start
+      end
+    end
+
+    def stop
+      log.warn "synapse: multi watcher exiting"
+
+      @watchers.values.each do |w|
+        w.stop
+      end
+    end
+
+    def ping?
+      @watchers.values.all? do |w|
+        w.ping?
+      end
+    end
+
+    private
+
+    def validate_discovery_opts
+      raise ArgumentError, "invalid discovery method '#{@discovery['method']}' for multi watcher" \
+        unless @discovery['method'] == 'multi'
+
+      raise ArgumentError, "watcher config is empty" if @discovery['watchers'].empty?
+    end
+  end
+end

--- a/lib/synapse/service_watcher/multi.rb
+++ b/lib/synapse/service_watcher/multi.rb
@@ -29,26 +29,17 @@ class Synapse::ServiceWatcher
       super(opts, reconfigure_callback, synapse)
 
       @watchers = {}
-
       watcher_config = @discovery['watchers'] || {}
 
-      watcher_config.each do |name, config|
+      watcher_config.each do |watcher_name, watcher_config|
         # Merge (deep-cloned) top-level config with the discovery configuration.
         merged_config = Marshal.load(Marshal.dump(opts))
-        merged_config['discovery'] = config
+        merged_config['discovery'] = watcher_config
 
-        unless config.is_a?(Hash)
-          raise ArgumentError, "Child watcher is not a hash for watcher #{name}"
-        end
-
-        unless config.has_key?('method')
-          raise ArgumentError, "Discovery method not included in config for watcher #{name}"
-        end
-
-        discovery_method = config['method']
+        discovery_method = watcher_config['method']
         watcher = Synapse::ServiceWatcher.load_watcher(discovery_method, merged_config, synapse)
 
-        @watchers[name] = watcher
+        @watchers[watcher_name] = watcher
       end
     end
 
@@ -81,6 +72,16 @@ class Synapse::ServiceWatcher
         unless @discovery['method'] == 'multi'
 
       raise ArgumentError, "watcher config is empty" if @discovery['watchers'].empty?
+
+      @discovery['watchers'].each do |watcher_name, watcher_config|
+        unless watcher_config.is_a?(Hash)
+          raise ArgumentError, "Child watcher is not a hash for watcher #{watcher_name}"
+        end
+
+        unless watcher_config.has_key?('method')
+          raise ArgumentError, "Discovery method not included in config for watcher #{watcher_name}"
+        end
+      end
     end
   end
 end

--- a/lib/synapse/service_watcher/multi.rb
+++ b/lib/synapse/service_watcher/multi.rb
@@ -39,7 +39,7 @@ class Synapse::ServiceWatcher
         merged_config = Marshal.load(Marshal.dump(opts))
         merged_config['discovery'] = watcher_config
 
-        discovery_method = config['method']
+        discovery_method = watcher_config['method']
         watcher = Synapse::ServiceWatcher.load_watcher(discovery_method,
                                                        merged_config,
                                                        @child_notification_callback,
@@ -69,6 +69,11 @@ class Synapse::ServiceWatcher
       @watchers.values.all? do |w|
         w.ping?
       end
+    end
+
+    def backends
+      # TODO: return the resolved backends
+      return [{'host' => 'abc', 'port' => 1234, 'name' => 'i-test'}]
     end
 
     private

--- a/lib/synapse/service_watcher/multi.rb
+++ b/lib/synapse/service_watcher/multi.rb
@@ -71,7 +71,12 @@ class Synapse::ServiceWatcher
       raise ArgumentError, "invalid discovery method '#{@discovery['method']}' for multi watcher" \
         unless @discovery['method'] == 'multi'
 
+      raise ArgumentError, "watchers not defined" unless @discovery.has_key?('watchers')
       raise ArgumentError, "watcher config is empty" if @discovery['watchers'].empty?
+
+      raise ArgumentError, "resolver not defined" unless @discovery.has_key?('resolver')
+      raise ArgumentError, "resolver config is empty" if @discovery['resolver'].empty?
+      raise ArgumentError, "resolver method undefined" unless @discovery['resolver'].has_key?('method')
 
       @discovery['watchers'].each do |watcher_name, watcher_config|
         unless watcher_config.is_a?(Hash)

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -26,8 +26,8 @@ class Synapse::ServiceWatcher
     @@zk_pool_count = {}
     @@zk_pool_lock = Mutex.new
 
-    def initialize(opts={}, synapse)
-      super(opts, synapse)
+    def initialize(opts={}, reconfigure_callback=nil, synapse)
+      super(opts, reconfigure_callback, synapse)
 
       # Alternative deserialization support. By default we use nerve
       # deserialization, but we also support serverset registries

--- a/lib/synapse/service_watcher/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns.rb
@@ -51,11 +51,11 @@ class Synapse::ServiceWatcher
       # Overrides the discovery_servers method on the parent class
       attr_accessor :discovery_servers
 
-      def initialize(opts={}, parent=nil, synapse, message_queue)
+      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
         @message_queue = message_queue
         @parent = parent
 
-        super(opts, synapse)
+        super(opts, reconfigure_callback, synapse)
       end
 
       def stop
@@ -113,8 +113,8 @@ class Synapse::ServiceWatcher
     end
 
     class Zookeeper < Synapse::ServiceWatcher::ZookeeperWatcher
-      def initialize(opts={}, parent=nil, synapse, message_queue)
-        super(opts, synapse)
+      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
+        super(opts, reconfigure_callback, synapse)
 
         @message_queue = message_queue
         @parent = parent

--- a/spec/bin/synapse_spec.rb
+++ b/spec/bin/synapse_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'tempfile'
+require 'synapse/service_watcher/multi'
 
 describe 'parseconfig' do
   it 'parses a templated config' do
@@ -52,5 +53,51 @@ describe 'parseconfig' do
     expect {
       load "#{File.dirname(__FILE__)}/../../bin/synapse"
     }.to raise_error(SyntaxError)
+  end
+
+  it 'parses discovery_multi configuration properly' do
+    allow_any_instance_of(Synapse::Synapse).to receive(:run)
+
+    expect(Synapse::Synapse).to receive(:new).exactly(:once).and_call_original
+    expect(Synapse::ServiceWatcher::MultiWatcher)
+      .to receive(:new)
+      .exactly(:once)
+      .with({"discovery" => {
+               "method" => "multi",
+               "resolver" => {
+                 "method" => "fallback",
+               },
+               "watchers" => {
+                 "primary" => {
+                   "method" => "zookeeper",
+                   "path" => "/services/service1",
+                   "discovery_jitter" => 25,
+                   "hosts" => ["localhost:2181", "localhost:2182", "localhost:2183"],
+                 },
+                 "secondary" => {
+                   "method" => "zookeeper",
+                   "path" => "/services/service1",
+                   "discovery_jitter" => 5,
+                   "hosts" => ["localhost:2184", "localhost:2185", "localhost:2186"],
+                 },
+               }
+             },
+             "haproxy" => {
+               "port" => 3213,
+               "server_options" => "check inter 2s rise 3 fall 2",
+               "bind_options" => "ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305",
+               "listen" => [
+                 "mode http",
+                 "option httpchk /health",
+                 "http-check expect string OK",
+               ]
+             },
+            "name" => "service1"}, nil, instance_of(Synapse::Synapse))
+
+    stub_const 'ENV', ENV.to_hash.merge(
+      {"SYNAPSE_CONFIG" => "#{File.dirname(__FILE__)}/../../config/discovery-multi.conf.json"})
+    stub_const 'ARGV', []
+
+    load "#{File.dirname(__FILE__)}/../../bin/synapse"
   end
 end

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -22,15 +22,21 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     args
   end
 
-  context "can construct normally" do
+  context "with normal arguments" do
     let(:args) { testargs }
-    it('can at least construct') { expect { subject }.not_to raise_error }
+
+    it 'can construct properly' do
+      expect { subject }.not_to raise_error
+    end
   end
 
   ['name', 'discovery'].each do |to_remove|
     context "without #{to_remove} argument" do
       let(:args) { remove_arg to_remove }
-      it('gots bang') { expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}") }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}")
+      end
     end
   end
 

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi'
+require 'synapse/service_watcher/zookeeper'
+require 'synapse/service_watcher/dns'
+
+describe Synapse::ServiceWatcher::MultiWatcher do
+  let(:mock_synapse) do
+    mock_synapse = instance_double(Synapse::Synapse)
+    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
+    allow(mock_synapse).to receive(:available_generators).and_return({
+      'haproxy' => mockgenerator
+    })
+    mock_synapse
+  end
+
+  subject {
+    Synapse::ServiceWatcher::MultiWatcher.new(config, mock_synapse)
+  }
+
+  let(:discovery) do
+    valid_discovery
+  end
+
+  let (:zk_discovery) do
+    {'method' => 'zookeeper', 'hosts' => 'localhost:2181', 'path' => '/smartstack'}
+  end
+
+  let (:dns_discovery) do
+    {'method' => 'dns', 'servers' => ['localhost']}
+  end
+
+  let(:valid_discovery) do
+    {'method' => 'multi', 'watchers' => {
+       'primary' => zk_discovery,
+       'secondary' => dns_discovery,
+     }}
+  end
+
+  let(:config) do
+    {
+      'name' => 'test',
+      'haproxy' => {},
+      'discovery' => discovery,
+    }
+  end
+
+  describe '.initialize' do
+    subject {
+      Synapse::ServiceWatcher::MultiWatcher
+    }
+
+    context 'with empty configuration' do
+      let(:discovery) do
+        {}
+      end
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with empty watcher configuration' do
+      let(:discovery) do
+        {'method' => 'multi', 'watchers' => {}}
+      end
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with wrong method type' do
+      let(:discovery) do
+        {'method' => 'zookeeper', 'watchers' => {}}
+      end
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid configuration' do
+      let(:discovery) do
+        valid_discovery
+      end
+
+      it 'creates the requested watchers' do
+        expect(Synapse::ServiceWatcher::ZookeeperWatcher)
+          .to receive(:new)
+          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => zk_discovery}, mock_synapse)
+          .and_call_original
+        expect(Synapse::ServiceWatcher::DnsWatcher)
+          .to receive(:new)
+          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => dns_discovery}, mock_synapse)
+          .and_call_original
+
+        expect {
+          subject.new(config, mock_synapse)
+        }.not_to raise_error
+      end
+
+      it 'has sets @watchers to each watcher' do
+        multi_watcher = subject.new(config, mock_synapse)
+        watchers = multi_watcher.instance_variable_get(:@watchers)
+
+        expect(watchers.has_key?('primary'))
+        expect(watchers.has_key?('secondary'))
+
+        expect(watchers['primary']).to be_instance_of(Synapse::ServiceWatcher::ZookeeperWatcher)
+        expect(watchers['secondary']).to be_instance_of(Synapse::ServiceWatcher::DnsWatcher)
+      end
+    end
+  end
+
+  describe '.start' do
+    it 'starts all child watchers' do
+      watchers = subject.instance_variable_get(:@watchers).values
+      watchers.each do |w|
+        expect(w).to receive(:start)
+      end
+
+      expect {
+        subject.start
+      }.not_to raise_error
+    end
+  end
+
+  describe '.stop' do
+    it 'stops all child watchers' do
+      watchers = subject.instance_variable_get(:@watchers).values
+      watchers.each do |w|
+        expect(w).to receive(:stop)
+      end
+
+      expect {
+        subject.stop
+      }.not_to raise_error
+    end
+  end
+
+  describe ".ping?" do
+    it 'calls ping? on all watchers' do
+      watchers = subject.instance_variable_get(:@watchers).values
+      watchers.each do |w|
+        expect(w).to receive(:ping?)
+      end
+
+      expect {
+        subject.ping?
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -47,6 +47,14 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     }
   end
 
+  let(:new_hosts) do
+    [{
+      'host' => 'test',
+      'port' => 1234,
+      'name' => 'i-test',
+    }]
+  end
+
   describe '.initialize' do
     subject {
       Synapse::ServiceWatcher::MultiWatcher
@@ -179,7 +187,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
         }.not_to raise_error
       end
 
-      it 'has sets @watchers to each watcher' do
+      it 'sets @watchers to each watcher' do
         multi_watcher = subject.new(config, mock_synapse)
         watchers = multi_watcher.instance_variable_get(:@watchers)
 
@@ -228,6 +236,41 @@ describe Synapse::ServiceWatcher::MultiWatcher do
       expect {
         subject.ping?
       }.not_to raise_error
+    end
+  end
+
+  describe "reconfigure!" do
+    it "only calls synapse reconfigure from parent" do
+      expect(mock_synapse).to receive(:reconfigure!).exactly(:once)
+      subject.send(:reconfigure!)
+    end
+  end
+
+  describe "children watchers" do
+    describe ".reconfigure!" do
+      it "does not call synapse reconfigure" do
+        expect(mock_synapse).not_to receive(:reconfigure!)
+
+        watchers = subject.instance_variable_get(:@watchers).values
+        watchers.each do |w|
+          w.send(:reconfigure!)
+        end
+      end
+
+      it "notifies parent"
+    end
+
+    describe "set_backends" do
+      it "does not call synapse reconfigure" do
+        expect(mock_synapse).not_to receive(:reconfigure!)
+
+        watchers = subject.instance_variable_get(:@watchers).values
+        watchers.each do |w|
+          w.send(:set_backends, new_hosts)
+        end
+      end
+
+      it "notifies parent"
     end
   end
 end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -85,6 +85,36 @@ describe Synapse::ServiceWatcher::MultiWatcher do
       end
     end
 
+    context 'with invalid child watcher definition' do
+      let(:discovery) {
+        {'method' => 'multi', 'watchers' => {
+           'secondary' => {
+             'method' => 'bogus',
+           }
+         }}
+      }
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with invalid child watcher type' do
+      let(:discovery) {
+        {'method' => 'multi', 'watchers' => {
+           'child' => 'not_a_hash'
+         }}
+      }
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
     context 'with valid configuration' do
       let(:discovery) do
         valid_discovery

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -33,6 +33,9 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     {'method' => 'multi', 'watchers' => {
        'primary' => zk_discovery,
        'secondary' => dns_discovery,
+     },
+     'resolver' => {
+       'method' => 'fallback',
      }}
   end
 
@@ -64,6 +67,18 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     context 'with empty watcher configuration' do
       let(:discovery) do
         {'method' => 'multi', 'watchers' => {}}
+      end
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with undefined watchers' do
+      let(:discovery) do
+        {'method' => 'muli'}
       end
 
       it 'raises an error' do
@@ -107,6 +122,35 @@ describe Synapse::ServiceWatcher::MultiWatcher do
            'child' => 'not_a_hash'
          }}
       }
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with undefined resolver' do
+      let(:discovery) do
+        {'method' => 'multi', 'watchers' => {
+           'child' => zk_discovery
+         }}
+      end
+
+      it 'raises an error' do
+        expect {
+          subject.new(config, mock_synapse)
+        }.to raise_error ArgumentError
+      end
+    end
+
+    context 'with empty resolver' do
+      let(:discovery) do
+        {'method' => 'multi', 'watchers' => {
+           'child' => zk_discovery
+         },
+        'resolver' => {}}
+      end
 
       it 'raises an error' do
         expect {

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -30,7 +30,12 @@ describe Synapse::ServiceWatcher::MultiWatcher do
   end
 
   let(:valid_discovery) do
-    {'method' => 'multi', 'watchers' => {
+    {'method' => 'multi',
+     'resolver' => {
+       'method' => 's3_toggle',
+       'default' => 'primary',
+     },
+     'watchers' => {
        'primary' => zk_discovery,
        'secondary' => dns_discovery,
      },

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -93,11 +93,11 @@ describe Synapse::ServiceWatcher::MultiWatcher do
       it 'creates the requested watchers' do
         expect(Synapse::ServiceWatcher::ZookeeperWatcher)
           .to receive(:new)
-          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => zk_discovery}, mock_synapse)
+          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => zk_discovery}, nil, mock_synapse)
           .and_call_original
         expect(Synapse::ServiceWatcher::DnsWatcher)
           .to receive(:new)
-          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => dns_discovery}, mock_synapse)
+          .with({'name' => 'test', 'haproxy' => {}, 'discovery' => dns_discovery}, nil, mock_synapse)
           .and_call_original
 
         expect {
@@ -148,7 +148,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     it 'calls ping? on all watchers' do
       watchers = subject.instance_variable_get(:@watchers).values
       watchers.each do |w|
-        expect(w).to receive(:ping?)
+        expect(w).to receive(:ping?).and_return true
       end
 
       expect {

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -38,6 +38,10 @@ describe Synapse::ServiceWatcher do
   end
 
   context 'service watcher dispatch' do
+    let (:base_config) {{
+      'method' => 'base',
+    }}
+
     let (:zookeeper_config) {{
       'method' => 'zookeeper',
       'hosts' => 'localhost:2181',
@@ -72,31 +76,42 @@ describe Synapse::ServiceWatcher do
       'application_name' => 'foobar',
     }}
 
+    it 'creates base correctly' do
+      expect {
+        subject.create('test', replace_discovery(base_config), mock_synapse)
+      }.not_to raise_error
+    end
+
     it 'creates zookeeper correctly' do
       expect {
         subject.create('test', replace_discovery(zookeeper_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates dns correctly' do
       expect {
         subject.create('test', replace_discovery(dns_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates docker correctly' do
       expect {
         subject.create('test', replace_discovery(docker_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates ec2tag correctly' do
       expect {
         subject.create('test', replace_discovery(ec2_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates zookeeper_dns correctly' do
       expect {
         subject.create('test', replace_discovery(zookeeper_dns_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates marathon correctly' do
       expect {
         subject.create('test', replace_discovery(marathon_config), mock_synapse)

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -169,13 +169,139 @@ describe Synapse::ServiceWatcher do
                            'aws_access_key_id' => 'bogus',
                            'aws_secret_access_key' => 'morebogus',
                            'aws_region' => 'evenmorebogus',
-                         }}
+                         }},
+          'resolver' => {
+            'method' => 'fallback',
+          }
         }
       }
 
       it 'creates watcher correctly' do
         expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
         expect{ subject }.not_to raise_error
+      end
+    end
+
+    context 'with discovery_multi present' do
+      let(:discovery) {
+        {
+          'method' => 'zookeeper',
+          'hosts' => 'localhost:2181',
+          'path' => '/smartstack',
+        }
+      }
+      let(:watchers) {
+        {
+          'secondary' => {
+            'method' => 'ec2tag',
+            'tag_name' => 'footag',
+            'tag_value' => 'barvalue',
+            'aws_access_key_id' => 'bogus',
+            'aws_secret_access_key' => 'morebogus',
+            'aws_region' => 'evenmorebogus',
+          }}
+      }
+
+      let(:discovery_multi) {
+        {
+          'watchers' => watchers,
+          'resolver' => {
+            'method' => 'fallback',
+          }
+        }
+      }
+
+      let(:config) {
+        {
+          'haproxy' => {
+            'port' => '8080',
+            'server_port_override' => '8081',
+          },
+          'discovery' => discovery,
+          'discovery_multi' => discovery_multi,
+        }
+      }
+
+      let(:expected_config) {
+        expected_config = Marshal.load(Marshal.dump(config))
+        expected_config['name'] = 'test'
+        expected_config['discovery'] = Marshal.load(Marshal.dump(discovery_multi))
+        expected_config['discovery']['watchers']['primary'] = discovery
+        expected_config['discovery']['method'] = 'multi'
+        expected_config.delete('discovery_multi')
+
+        expected_config
+      }
+
+      it 'creates watcher correctly' do
+        expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(expected_config, nil, mock_synapse)
+        expect{ subject }.not_to raise_error
+      end
+
+      context 'with method already set' do
+        let(:multi_method) { 'multi' }
+
+        let(:discovery_multi) {
+          {
+            'method' => multi_method,
+            'watchers' => watchers,
+            'resolver' => {
+              'method' => 'fallback',
+            }
+          }
+        }
+
+        context 'to not multi' do
+          let(:multi_method) { 'bogus' }
+
+          it 'raises an error' do
+            expect{ subject }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'to multi' do
+          it 'creates watcher properly' do
+            expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(expected_config, nil, mock_synapse)
+            expect{ subject }.not_to raise_error
+          end
+        end
+      end
+
+      context 'without any watchers set' do
+        let(:watchers) {{}}
+
+        it 'creates watcher properly' do
+          expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(expected_config, nil, mock_synapse)
+          expect{ subject }.not_to raise_error
+        end
+      end
+
+      context 'with discovery nil' do
+        let(:discovery) { nil }
+
+        it 'creates watcher properly' do
+          expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(expected_config, nil, mock_synapse)
+          expect{ subject }.not_to raise_error
+        end
+      end
+
+      context 'with primary already set' do
+        let(:watchers) {
+          {'primary' => discovery}
+        }
+        it 'raises an error' do
+          expect{ subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'with watchers invalid' do
+        let(:watchers) {
+          {'secondary' => {'method' => 'bogus'}}
+        }
+
+        it 'raises an error' do
+          expect{ subject }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -39,7 +39,6 @@ describe Synapse::ServiceWatcher do
     subject {
       Synapse::ServiceWatcher.create('test', config, mock_synapse)
     }
-    
     context 'with method => base' do
       let(:discovery_config) {
         {
@@ -153,8 +152,32 @@ describe Synapse::ServiceWatcher do
         expect{ subject }.not_to raise_error
       end
     end
+
+    context 'with method => multi' do
+      let(:discovery_config) {
+        {
+          'method' => 'multi',
+          'watchers' => {'primary' => {
+                           'method' => 'zookeeper',
+                           'hosts' => 'localhost:2181',
+                           'path' => '/smartstack',
+                         },
+                         'secondary' => {
+                           'method' => 'ec2tag',
+                           'tag_name' => 'footag',
+                           'tag_value' => 'barvalue',
+                           'aws_access_key_id' => 'bogus',
+                           'aws_secret_access_key' => 'morebogus',
+                           'aws_region' => 'evenmorebogus',
+                         }}
+        }
+      }
+
+      it 'creates watcher correctly' do
+        expect(Synapse::ServiceWatcher::MultiWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect{ subject }.not_to raise_error
+      end
+    end
   end
-
 end
-
 


### PR DESCRIPTION
## Summary
Add in a new `MultiWatcher` watcher type which can create multiple "child" watchers and then resolve their entries.

## PRs
- [x] #310
- [ ] #311 
- [x] #312 
- ~[ ] #313~
- [x] #314 
- [x] #315 

## Todo
- [ ] reducer method for `ping?` and backends
- [ ] configuration for reducer method
- [ ] documentation

## Tests
- [ ] unit tests
- [ ] creating multiple Zookeeper watchers
- [ ] resolution between multiple Zookeeper watchers

## Reviewers
TODO:
```
@austin-zhu @lcharignon @bsherrod 
```