### PR TITLE
Allow for configurable notification callback for watchers

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -122,14 +122,16 @@ module Synapse
     private
     def create_service_watchers(services={})
       service_watchers = []
+      reconfigure_callback = -> { reconfigure! }
+
       services.each do |service_name, service_config|
         if service_config.has_key?('load_test_concurrency')
           concurrency = service_config['load_test_concurrency']
           concurrency.times do |i|
-            service_watchers << ServiceWatcher.create("#{service_name}_#{i}", service_config, self, method(:reconfigure!))
+            service_watchers << ServiceWatcher.create("#{service_name}_#{i}", service_config, self, reconfigure_callback)
           end
         else
-          service_watchers << ServiceWatcher.create(service_name, service_config, self, method(:reconfigure!))
+          service_watchers << ServiceWatcher.create(service_name, service_config, self, reconfigure_callback)
         end
       end
 

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -126,10 +126,10 @@ module Synapse
         if service_config.has_key?('load_test_concurrency')
           concurrency = service_config['load_test_concurrency']
           concurrency.times do |i|
-            service_watchers << ServiceWatcher.create("#{service_name}_#{i}", service_config, self)
+            service_watchers << ServiceWatcher.create("#{service_name}_#{i}", service_config, self, method(:reconfigure!))
           end
         else
-          service_watchers << ServiceWatcher.create(service_name, service_config, self)
+          service_watchers << ServiceWatcher.create(service_name, service_config, self, method(:reconfigure!))
         end
       end
 

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -11,15 +11,20 @@ module Synapse
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
+      return self.load_watcher(discovery_method, opts, synapse)
+    end
+
+    def self.load_watcher(discovery_method, opts, synapse)
       watcher = begin
-        method = discovery_method.downcase
-        require "synapse/service_watcher/#{method}"
-        # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
-        method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
-        self.const_get("#{method_class}")
-      rescue Exception => e
-        raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
-      end
+                  method = discovery_method.downcase
+                  require "synapse/service_watcher/#{method}"
+                  # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
+                  method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
+                  self.const_get("#{method_class}")
+                rescue Exception => e
+                  raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
+                end
+
       return watcher.new(opts, synapse)
     end
   end

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,17 +4,17 @@ require "synapse/service_watcher/base"
 module Synapse
   class ServiceWatcher
     # the method which actually dispatches watcher creation requests
-    def self.create(name, opts, reconfigure_callback = nil, synapse)
+    def self.create(name, opts, synapse, reconfigure_callback)
       opts['name'] = name
 
       raise ArgumentError, "Missing discovery method when trying to create watcher" \
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
-      return self.load_watcher(discovery_method, opts, reconfigure_callback, synapse)
+      return self.load_watcher(discovery_method, opts, synapse, reconfigure_callback)
     end
 
-    def self.load_watcher(discovery_method, opts, reconfigure_callback = nil, synapse)
+    def self.load_watcher(discovery_method, opts, synapse, reconfigure_callback)
       watcher = begin
         method = discovery_method.downcase
         require "synapse/service_watcher/#{method}"
@@ -25,7 +25,7 @@ module Synapse
         raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
       end
 
-      return watcher.new(opts, reconfigure_callback, synapse)
+      return watcher.new(opts, synapse, reconfigure_callback)
     end
   end
 end

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -16,14 +16,14 @@ module Synapse
 
     def self.load_watcher(discovery_method, opts, reconfigure_callback = nil, synapse)
       watcher = begin
-                  method = discovery_method.downcase
-                  require "synapse/service_watcher/#{method}"
-                  # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
-                  method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
-                  self.const_get("#{method_class}")
-                rescue Exception => e
-                  raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
-                end
+        method = discovery_method.downcase
+        require "synapse/service_watcher/#{method}"
+        # zookeeper_dns => ZookeeperDnsWatcher, ec2tag => Ec2tagWatcher, etc ...
+        method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Watcher')
+        self.const_get("#{method_class}")
+      rescue Exception => e
+        raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
+      end
 
       return watcher.new(opts, reconfigure_callback, synapse)
     end

--- a/lib/synapse/service_watcher.rb
+++ b/lib/synapse/service_watcher.rb
@@ -4,17 +4,17 @@ require "synapse/service_watcher/base"
 module Synapse
   class ServiceWatcher
     # the method which actually dispatches watcher creation requests
-    def self.create(name, opts, synapse)
+    def self.create(name, opts, reconfigure_callback = nil, synapse)
       opts['name'] = name
 
       raise ArgumentError, "Missing discovery method when trying to create watcher" \
         unless opts.has_key?('discovery') && opts['discovery'].has_key?('method')
 
       discovery_method = opts['discovery']['method']
-      return self.load_watcher(discovery_method, opts, synapse)
+      return self.load_watcher(discovery_method, opts, reconfigure_callback, synapse)
     end
 
-    def self.load_watcher(discovery_method, opts, synapse)
+    def self.load_watcher(discovery_method, opts, reconfigure_callback = nil, synapse)
       watcher = begin
                   method = discovery_method.downcase
                   require "synapse/service_watcher/#{method}"
@@ -25,7 +25,7 @@ module Synapse
                   raise ArgumentError, "Specified a discovery method of #{discovery_method}, which could not be found: #{e}"
                 end
 
-      return watcher.new(opts, synapse)
+      return watcher.new(opts, reconfigure_callback, synapse)
     end
   end
 end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -20,10 +20,10 @@ class Synapse::ServiceWatcher
       @synapse = synapse
       @revision = 0
       @reconfigure_callback = if reconfigure_callback.nil?
-                                lambda { synapse.reconfigure! }
-                              else
-                                reconfigure_callback
-                              end
+        lambda { synapse.reconfigure! }
+      else
+        reconfigure_callback
+      end
 
       # set required service parameters
       %w{name discovery}.each do |req|

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -14,11 +14,16 @@ class Synapse::ServiceWatcher
 
     attr_reader :name, :revision
 
-    def initialize(opts={}, synapse)
+    def initialize(opts={}, reconfigure_callback=nil, synapse)
       super()
 
       @synapse = synapse
       @revision = 0
+      @reconfigure_callback = if reconfigure_callback.nil?
+                                lambda { synapse.reconfigure! }
+                              else
+                                reconfigure_callback
+                              end
 
       # set required service parameters
       %w{name discovery}.each do |req|
@@ -241,7 +246,7 @@ class Synapse::ServiceWatcher
     # can be overridden in subclasses.
     def reconfigure!
       @revision += 1
-      @synapse.reconfigure!
+      @reconfigure_callback.call
     end
   end
 end

--- a/lib/synapse/service_watcher/base.rb
+++ b/lib/synapse/service_watcher/base.rb
@@ -14,16 +14,14 @@ class Synapse::ServiceWatcher
 
     attr_reader :name, :revision
 
-    def initialize(opts={}, reconfigure_callback=nil, synapse)
+    def initialize(opts={}, synapse, reconfigure_callback)
       super()
 
       @synapse = synapse
       @revision = 0
-      @reconfigure_callback = if reconfigure_callback.nil?
-        lambda { synapse.reconfigure! }
-      else
-        reconfigure_callback
-      end
+
+      raise ArgumentError, "reconfigure callback is nil" if reconfigure_callback.nil?
+      @reconfigure_callback = reconfigure_callback
 
       # set required service parameters
       %w{name discovery}.each do |req|

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -26,8 +26,8 @@ class Synapse::ServiceWatcher
     @@zk_pool_count = {}
     @@zk_pool_lock = Mutex.new
 
-    def initialize(opts={}, reconfigure_callback=nil, synapse)
-      super(opts, reconfigure_callback, synapse)
+    def initialize(opts={}, synapse, reconfigure_callback)
+      super(opts, synapse, reconfigure_callback)
 
       # Alternative deserialization support. By default we use nerve
       # deserialization, but we also support serverset registries

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -26,8 +26,8 @@ class Synapse::ServiceWatcher
     @@zk_pool_count = {}
     @@zk_pool_lock = Mutex.new
 
-    def initialize(opts={}, synapse)
-      super(opts, synapse)
+    def initialize(opts={}, reconfigure_callback=nil, synapse)
+      super(opts, reconfigure_callback, synapse)
 
       # Alternative deserialization support. By default we use nerve
       # deserialization, but we also support serverset registries

--- a/lib/synapse/service_watcher/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns.rb
@@ -51,11 +51,11 @@ class Synapse::ServiceWatcher
       # Overrides the discovery_servers method on the parent class
       attr_accessor :discovery_servers
 
-      def initialize(opts={}, parent=nil, synapse, message_queue)
+      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
         @message_queue = message_queue
         @parent = parent
 
-        super(opts, synapse)
+        super(opts, reconfigure_callback, synapse)
       end
 
       def stop
@@ -113,8 +113,8 @@ class Synapse::ServiceWatcher
     end
 
     class Zookeeper < Synapse::ServiceWatcher::ZookeeperWatcher
-      def initialize(opts={}, parent=nil, synapse, message_queue)
-        super(opts, synapse)
+      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
+        super(opts, reconfigure_callback, synapse)
 
         @message_queue = message_queue
         @parent = parent

--- a/lib/synapse/service_watcher/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns.rb
@@ -51,11 +51,11 @@ class Synapse::ServiceWatcher
       # Overrides the discovery_servers method on the parent class
       attr_accessor :discovery_servers
 
-      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
+      def initialize(opts={}, parent=nil, synapse, reconfigure_callback, message_queue)
         @message_queue = message_queue
         @parent = parent
 
-        super(opts, reconfigure_callback, synapse)
+        super(opts, synapse, reconfigure_callback)
       end
 
       def stop
@@ -113,8 +113,8 @@ class Synapse::ServiceWatcher
     end
 
     class Zookeeper < Synapse::ServiceWatcher::ZookeeperWatcher
-      def initialize(opts={}, reconfigure_callback=nil, parent=nil, synapse, message_queue)
-        super(opts, reconfigure_callback, synapse)
+      def initialize(opts={}, parent=nil, synapse, reconfigure_callback, message_queue)
+        super(opts, synapse, reconfigure_callback)
 
         @message_queue = message_queue
         @parent = parent
@@ -155,6 +155,7 @@ class Synapse::ServiceWatcher
         mk_child_watcher_opts(dns_discovery_opts),
         self,
         @synapse,
+        @reconfigure_callback,
         @message_queue
       )
 
@@ -162,6 +163,7 @@ class Synapse::ServiceWatcher
         mk_child_watcher_opts(zookeeper_discovery_opts),
         self,
         @synapse,
+        @reconfigure_callback,
         @message_queue
       )
 

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -22,15 +22,21 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     args
   end
 
-  context "can construct normally" do
+  context "with normal arguments" do
     let(:args) { testargs }
-    it('can at least construct') { expect { subject }.not_to raise_error }
+
+    it 'can construct properly' do
+      expect { subject }.not_to raise_error
+    end
   end
 
   ['name', 'discovery'].each do |to_remove|
     context "without #{to_remove} argument" do
       let(:args) { remove_arg to_remove }
-      it('gots bang') { expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}") }
+
+      it 'raises error' do
+        expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}")
+      end
     end
   end
 

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -13,7 +13,7 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     })
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse, lambda {} ) }
+  subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse, -> {} ) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'base' }, 'haproxy' => {} }}
 
   def remove_arg(name)
@@ -264,7 +264,7 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     end
 
     context "with custom callback" do
-      let(:cb) { lambda {} }
+      let(:cb) { -> {} }
       subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse, cb) }
 
       it "calls custom callback" do

--- a/spec/lib/synapse/service_watcher_base_spec.rb
+++ b/spec/lib/synapse/service_watcher_base_spec.rb
@@ -13,7 +13,7 @@ describe Synapse::ServiceWatcher::BaseWatcher do
     })
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse) }
+  subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse, lambda {} ) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'base' }, 'haproxy' => {} }}
 
   def remove_arg(name)
@@ -44,6 +44,14 @@ describe Synapse::ServiceWatcher::BaseWatcher do
       it 'raises error' do
         expect { subject }.to raise_error(ArgumentError, "missing required option #{to_remove}")
       end
+    end
+  end
+
+  context "without reconfigure callback" do
+    it "raises an error" do
+      expect {
+        Synapse::ServiceWatcher::BaseWatcher.new(testargs, mocksynapse)
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -247,37 +255,17 @@ describe Synapse::ServiceWatcher::BaseWatcher do
   describe "reconfigure!" do
     let(:args) { testargs }
 
-    context "without custom callback" do
+    context "with explicit nil custom callback" do
       subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse) }
 
-      it "calls synapse reconfigure" do
-        expect(mocksynapse).to receive(:reconfigure!).exactly(:once)
-        subject.send(:reconfigure!)
-      end
-
-      it "increments revision" do
-        allow(mocksynapse).to receive(:reconfigure!)
-        expect{subject.send(:reconfigure!)}.to change{subject.revision}.by 1
-      end
-    end
-
-    context "with explicit nil custom callback" do
-      subject { Synapse::ServiceWatcher::BaseWatcher.new(args, nil, mocksynapse) }
-
-      it "calls synapse reconfigure" do
-        expect(mocksynapse).to receive(:reconfigure!).exactly(:once)
-        subject.send(:reconfigure!)
-      end
-
-      it "increments revision" do
-        allow(mocksynapse).to receive(:reconfigure!).exactly(:once)
-        expect{subject.send(:reconfigure!)}.to change{subject.revision}.by 1
+      it "raises an error" do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
 
     context "with custom callback" do
       let(:cb) { lambda {} }
-      subject { Synapse::ServiceWatcher::BaseWatcher.new(args, cb, mocksynapse) }
+      subject { Synapse::ServiceWatcher::BaseWatcher.new(args, mocksynapse, cb) }
 
       it "calls custom callback" do
         expect(mocksynapse).not_to receive(:reconfigure!)

--- a/spec/lib/synapse/service_watcher_dns_spec.rb
+++ b/spec/lib/synapse/service_watcher_dns_spec.rb
@@ -35,7 +35,7 @@ describe Synapse::ServiceWatcher::DnsWatcher do
     ]
   end
 
-  subject { Synapse::ServiceWatcher::DnsWatcher.new(config, mock_synapse) }
+  subject { Synapse::ServiceWatcher::DnsWatcher.new(config, mock_synapse, lambda {}) }
 
   it 'only resolves hostnames' do
     resolver = instance_double("Resolv::DNS")

--- a/spec/lib/synapse/service_watcher_dns_spec.rb
+++ b/spec/lib/synapse/service_watcher_dns_spec.rb
@@ -35,7 +35,7 @@ describe Synapse::ServiceWatcher::DnsWatcher do
     ]
   end
 
-  subject { Synapse::ServiceWatcher::DnsWatcher.new(config, mock_synapse, lambda {}) }
+  subject { Synapse::ServiceWatcher::DnsWatcher.new(config, mock_synapse, -> {}) }
 
   it 'only resolves hostnames' do
     resolver = instance_double("Resolv::DNS")

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -15,7 +15,7 @@ describe Synapse::ServiceWatcher::DockerWatcher do
     })
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::DockerWatcher.new(testargs, mocksynapse, lambda {}) }
+  subject { Synapse::ServiceWatcher::DockerWatcher.new(testargs, mocksynapse, -> {}) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'docker', 'servers' => [{'host' => 'server1.local', 'name' => 'mainserver'}], 'image_name' => 'mycool/image', 'container_port' => 6379 }, 'haproxy' => {} }}
   before(:each) do
     allow(subject.log).to receive(:warn)

--- a/spec/lib/synapse/service_watcher_docker_spec.rb
+++ b/spec/lib/synapse/service_watcher_docker_spec.rb
@@ -15,7 +15,7 @@ describe Synapse::ServiceWatcher::DockerWatcher do
     })
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::DockerWatcher.new(testargs, mocksynapse) }
+  subject { Synapse::ServiceWatcher::DockerWatcher.new(testargs, mocksynapse, lambda {}) }
   let(:testargs) { { 'name' => 'foo', 'discovery' => { 'method' => 'docker', 'servers' => [{'host' => 'server1.local', 'name' => 'mainserver'}], 'image_name' => 'mycool/image', 'container_port' => 6379 }, 'haproxy' => {} }}
   before(:each) do
     allow(subject.log).to receive(:warn)

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -39,7 +39,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     allow(mock_synapse).to receive(:reconfigure!).and_return(true)
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse, lambda {}) }
+  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse, -> {}) }
 
   let(:basic_config) do
     { 'name' => 'ec2tagtest',
@@ -103,27 +103,27 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     context 'when missing arguments' do
       it 'does not break if aws_region is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse, -> {})
         }.not_to raise_error
       end
       it 'does not break if aws_access_key_id is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse, -> {})
         }.not_to raise_error
       end
       it 'does not break if aws_secret_access_key is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse, -> {})
         }.not_to raise_error
       end
       it 'complains if server_port_override and backend_port_override are missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_haproxy_arg('server_port_override'), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_haproxy_arg('server_port_override'), mock_synapse, -> {})
         }.to raise_error(ArgumentError, /Missing backend_port_override/)
       end
       it 'does not break if backend_port_override is set' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_arg('backend_port_override', 1234), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_arg('backend_port_override', 1234), mock_synapse, -> {})
         }.not_to raise_error
       end
     end
@@ -131,7 +131,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     context 'invalid data' do
       it 'complains if the haproxy server_port_override is not a number' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse, -> {})
         }.to raise_error(ArgumentError, /Invalid backend_port_override/)
       end
       it 'complains if the backend_port_override is not a number' do
@@ -139,7 +139,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
         expect(config['haproxy']['backend_port_override']).to eq(nil)
         config = munge_arg('backend_port_override', '80deadbeef')
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(config, mock_synapse, lambda {})
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(config, mock_synapse, -> {})
         }.to raise_error(ArgumentError, /Invalid backend_port_override/)
       end
 

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -39,7 +39,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     allow(mock_synapse).to receive(:reconfigure!).and_return(true)
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse) }
+  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse, lambda {}) }
 
   let(:basic_config) do
     { 'name' => 'ec2tagtest',
@@ -103,27 +103,27 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     context 'when missing arguments' do
       it 'does not break if aws_region is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_region'), mock_synapse, lambda {})
         }.not_to raise_error
       end
       it 'does not break if aws_access_key_id is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_access_key_id'), mock_synapse, lambda {})
         }.not_to raise_error
       end
       it 'does not break if aws_secret_access_key is missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_discovery_arg('aws_secret_access_key'), mock_synapse, lambda {})
         }.not_to raise_error
       end
       it 'complains if server_port_override and backend_port_override are missing' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_haproxy_arg('server_port_override'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(remove_haproxy_arg('server_port_override'), mock_synapse, lambda {})
         }.to raise_error(ArgumentError, /Missing backend_port_override/)
       end
       it 'does not break if backend_port_override is set' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_arg('backend_port_override', 1234), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_arg('backend_port_override', 1234), mock_synapse, lambda {})
         }.not_to raise_error
       end
     end
@@ -131,7 +131,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     context 'invalid data' do
       it 'complains if the haproxy server_port_override is not a number' do
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(munge_haproxy_arg('server_port_override', '80deadbeef'), mock_synapse, lambda {})
         }.to raise_error(ArgumentError, /Invalid backend_port_override/)
       end
       it 'complains if the backend_port_override is not a number' do
@@ -139,7 +139,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
         expect(config['haproxy']['backend_port_override']).to eq(nil)
         config = munge_arg('backend_port_override', '80deadbeef')
         expect {
-          Synapse::ServiceWatcher::Ec2tagWatcher.new(config, mock_synapse)
+          Synapse::ServiceWatcher::Ec2tagWatcher.new(config, mock_synapse, lambda {})
         }.to raise_error(ArgumentError, /Invalid backend_port_override/)
       end
 

--- a/spec/lib/synapse/service_watcher_marathon_spec.rb
+++ b/spec/lib/synapse/service_watcher_marathon_spec.rb
@@ -29,7 +29,7 @@ describe Synapse::ServiceWatcher::MarathonWatcher do
   end
   let(:marathon_response) { { 'tasks' => [] } }
 
-  subject { described_class.new(config, mocksynapse, lambda {}) }
+  subject { described_class.new(config, mocksynapse, -> {}) }
 
   before do
     allow(subject.log).to receive(:warn)

--- a/spec/lib/synapse/service_watcher_marathon_spec.rb
+++ b/spec/lib/synapse/service_watcher_marathon_spec.rb
@@ -29,7 +29,7 @@ describe Synapse::ServiceWatcher::MarathonWatcher do
   end
   let(:marathon_response) { { 'tasks' => [] } }
 
-  subject { described_class.new(config, mocksynapse) }
+  subject { described_class.new(config, mocksynapse, lambda {}) }
 
   before do
     allow(subject.log).to receive(:warn)

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -25,10 +25,18 @@ describe Synapse::ServiceWatcher do
     {}
   end
 
-  context 'bogus arguments' do
+  context 'with bogus method' do
     let(:discovery_config) {{'method' => 'bogus'}}
 
-    it 'complains if discovery method is bogus' do
+    it 'raises an error' do
+      expect {
+        subject.create('test', config, mock_synapse, lambda {})
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  context 'without reconfigure callback' do
+    it 'raises an error' do
       expect {
         subject.create('test', config, mock_synapse)
       }.to raise_error(ArgumentError)
@@ -36,10 +44,14 @@ describe Synapse::ServiceWatcher do
   end
 
   context 'service watcher dispatch' do
-    subject {
-      Synapse::ServiceWatcher.create('test', config, mock_synapse)
+    let(:default_callback) {
+      lambda {}
     }
-    
+
+    subject {
+      Synapse::ServiceWatcher.create('test', config, mock_synapse, default_callback)
+    }
+
     context 'with method => base' do
       let(:discovery_config) {
         {
@@ -48,7 +60,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::BaseWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::BaseWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect { subject }.not_to raise_error
       end
 
@@ -56,7 +68,7 @@ describe Synapse::ServiceWatcher do
         cb = lambda { }
         expect(cb).to receive(:call).exactly(:once)
 
-        watcher = Synapse::ServiceWatcher.create('test', config, cb, mock_synapse)
+        watcher = Synapse::ServiceWatcher.create('test', config, mock_synapse, cb)
         watcher.send(:reconfigure!)
       end
     end
@@ -71,7 +83,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect { subject }.not_to raise_error
       end
     end
@@ -85,7 +97,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::DnsWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::DnsWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect{ subject }.not_to raise_error
       end
     end
@@ -101,7 +113,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::DockerWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::DockerWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect{ subject }.not_to raise_error
       end
     end
@@ -119,7 +131,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::Ec2tagWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::Ec2tagWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect{ subject }.not_to raise_error
       end
     end
@@ -134,7 +146,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect{ subject }.not_to raise_error
       end
     end
@@ -149,7 +161,7 @@ describe Synapse::ServiceWatcher do
       }
 
       it 'creates watcher correctly' do
-        expect(Synapse::ServiceWatcher::MarathonWatcher).to receive(:new).exactly(:once).with(config, nil, mock_synapse)
+        expect(Synapse::ServiceWatcher::MarathonWatcher).to receive(:new).exactly(:once).with(config, mock_synapse, default_callback)
         expect{ subject }.not_to raise_error
       end
     end

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -38,6 +38,10 @@ describe Synapse::ServiceWatcher do
   end
 
   context 'service watcher dispatch' do
+    let (:base_config) {{
+      'method' => 'base',
+    }}
+
     let (:zookeeper_config) {{
       'method' => 'zookeeper',
       'hosts' => 'localhost:2181',
@@ -72,31 +76,42 @@ describe Synapse::ServiceWatcher do
       'application_name' => 'foobar',
     }}
 
+    it 'creates base correctly' do
+      expect {
+        subject.create('test', replace_discovery(base_config), mock_synapse)
+      }.not_to raise_error
+    end
+
     it 'creates zookeeper correctly' do
       expect {
         subject.create('test', replace_discovery(zookeeper_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates dns correctly' do
       expect {
         subject.create('test', replace_discovery(dns_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates docker correctly' do
       expect {
         subject.create('test', replace_discovery(docker_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates ec2tag correctly' do
       expect {
         subject.create('test', replace_discovery(ec2_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates zookeeper_dns correctly' do
       expect {
         subject.create('test', replace_discovery(zookeeper_dns_config), mock_synapse)
       }.not_to raise_error
     end
+
     it 'creates marathon correctly' do
       expect {
         subject.create('test', replace_discovery(marathon_config), mock_synapse)

--- a/spec/lib/synapse/service_watcher_spec.rb
+++ b/spec/lib/synapse/service_watcher_spec.rb
@@ -30,7 +30,7 @@ describe Synapse::ServiceWatcher do
 
     it 'raises an error' do
       expect {
-        subject.create('test', config, mock_synapse, lambda {})
+        subject.create('test', config, mock_synapse, -> {})
       }.to raise_error(ArgumentError)
     end
   end
@@ -45,7 +45,7 @@ describe Synapse::ServiceWatcher do
 
   context 'service watcher dispatch' do
     let(:default_callback) {
-      lambda {}
+      -> {}
     }
 
     subject {
@@ -65,7 +65,7 @@ describe Synapse::ServiceWatcher do
       end
 
       it 'passes custom callback' do
-        cb = lambda { }
+        cb = -> { }
         expect(cb).to receive(:call).exactly(:once)
 
         watcher = Synapse::ServiceWatcher.create('test', config, mock_synapse, cb)

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -84,7 +84,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       node_double
     end
 
-    subject { Synapse::ServiceWatcher::ZookeeperWatcher.new(config, mock_synapse) }
+    subject { Synapse::ServiceWatcher::ZookeeperWatcher.new(config, mock_synapse, lambda {}) }
     it 'decodes data correctly' do
       expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
     end
@@ -357,7 +357,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   context 'ZookeeperDnsWatcher' do
     let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => 'somehost','path' => 'some/path' } }
     let(:message_queue) { [] }
-    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, message_queue) }
+    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, lambda {}, message_queue) }
     it 'decodes data correctly' do
       expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
     end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -84,7 +84,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       node_double
     end
 
-    subject { Synapse::ServiceWatcher::ZookeeperWatcher.new(config, mock_synapse, lambda {}) }
+    subject { Synapse::ServiceWatcher::ZookeeperWatcher.new(config, mock_synapse, -> {}) }
     it 'decodes data correctly' do
       expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
     end
@@ -357,7 +357,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   context 'ZookeeperDnsWatcher' do
     let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => 'somehost','path' => 'some/path' } }
     let(:message_queue) { [] }
-    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, lambda {}, message_queue) }
+    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, -> {}, message_queue) }
     it 'decodes data correctly' do
       expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
     end

--- a/spec/lib/synapse_spec.rb
+++ b/spec/lib/synapse_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'synapse'
+require 'synapse/service_watcher/base'
+
+describe Synapse do
+  let(:discovery) {
+    {
+       "method" => "base"
+    }
+  }
+
+  let(:local_haproxy) {
+    {
+       "port" => 3213,
+       "server_options" => "check inter 2s rise 3 fall 2",
+       "bind_options" => "",
+       "listen" => [
+         "mode http",
+         "option httpcheck /health",
+         "http-check expect string OK"
+       ]
+     }
+  }
+
+  let(:service) {
+    {"discovery" => discovery, "haproxy" => local_haproxy}
+  }
+
+  let(:global_haproxy) {
+    {
+      "global" => [
+        "daemon",
+        "maxconn 4096",
+      ],
+      "defaults" => [],
+      "do_writes" => false,
+      "do_socket" => false,
+      "do_checks" => false,
+      "do_reloads" => false,
+    }
+  }
+
+  let(:config) {
+    {"services" => {
+       "service1" => service,
+     },
+     "haproxy" => global_haproxy,
+     }
+  }
+
+  subject {
+    Synapse::Synapse.new(config)
+  }
+
+  describe "#initialize" do
+    it 'creates watchers' do
+      expect(Synapse::ServiceWatcher::BaseWatcher)
+        .to receive(:new)
+        .exactly(:once)
+        .with(service, an_instance_of(Synapse::Synapse), duck_type(:call))
+
+      expect { subject }.not_to raise_error
+    end
+
+    it 'passes watchers proper reconfigure callback' do
+      expect(subject).to receive(:reconfigure!).exactly(:once)
+
+      watchers = subject.instance_variable_get(:@service_watchers)
+      expect(watchers.length).to eq(1)
+
+      watchers[0].send(:reconfigure!)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR allows for configuring a custom notification callback when a watcher has an update, instead of always called `synapse.reconfigure!` by default.

Note that the `BaseWatcher.reconfigure!` method essentially acts as a notification of an update: this triggers the main Synapse object to update the config generators (i.e. create new HAProxy configuration and reload the process).

This will be used as part of the multi-watcher (WIP: https://github.com/airbnb/synapse/pull/309), in order to allow the multi-watcher to receive notifications instead of the Synapse object. The multi-watcher will then notify Synapse directly, *after resolving the different child watchers.*  

## Tests
- [x] Unit tests

## Reviewers
@bsherrod @austin-zhu 