### PR TITLE
Add resolver interface and base resolver [stacked on top of #312]

### DIFF
--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -1,0 +1,56 @@
+# Resolvers
+
+A resolver decides how to combine, or resolve, multiple service watchers into a
+single result. That is, it operates as a `reducer` function to allow more than
+one service watchers to appear, and act, as a single watcher.
+
+The stub methods listed below should be overridden by any children classes.
+If any additional methods are overridden (such as `initialize`), be sure to
+call `super` first.
+
+```ruby
+require "synapse/service_watcher/multi/resolver/base"
+
+class Synapse::ServiceWatcher::MultiWatcher::Resolver
+   class MyResolver < BaseResolver
+      def start
+	     # start resolver
+	  end
+
+	  def stop
+	     # stop resolver
+	  end
+
+	  def backends
+	     # return a single list of backends
+	  end
+
+	  def ping?
+	     # return whether or not the watchers are healthy
+	  end
+   end
+end
+```
+
+### Resolver Plugin Interface
+Synapse deduces both the class path and class name from the `method` key within
+the resolver configuration.  Every resolver is passed configuration with the
+`method` key, e.g. `zookeeper` or `ec2tag`.
+
+#### Class Location
+Synapse expects to find your class at `synapse/service_watcher/multi/#{method}`.
+You must make your resolver available at that path, and Synapse can "just work" and
+find it.
+
+#### Class Name
+These method strings are then transformed into class names via the following
+function:
+
+```
+method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Resolver')
+```
+
+This has the effect of taking the method, splitting on '_', capitalizing each
+part and recombining with an added 'Resolver' on the end. So `fallback`
+becomes `FallbackResolver`, and `union` becomes `UnionResolver`. Make sure
+your class name is correct.

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -1,0 +1,38 @@
+require "synapse/log"
+require "synapse/statsd"
+
+class Synapse::ServiceWatcher::MultiWatcher::Resolver
+  class BaseResolver
+    include Synapse::Logging
+    include Synapse::StatsD
+
+    def initialize(opts, watchers)
+      super()
+
+      log.info "creating base resolver"
+
+      raise ArgumentError, "BaseResolver expects method to be base" unless opts['method'] == 'base'
+      raise ArgumentError, "no watchers provided" unless watchers.length > 0
+    end
+
+    # should be overridden in child classes
+    def start
+      log.info "starting base resolver"
+    end
+
+    # should be overridden in child classes
+    def stop
+      log.info "stopping base resolver"
+    end
+
+    # should be overridden in child classes
+    def backends
+      return []
+    end
+
+    # should be overridden in child classes
+    def ping?
+      return true
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -3,29 +3,13 @@ require 'synapse/service_watcher/multi/resolver/base'
 require 'synapse/service_watcher/base/base'
 
 describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
-  let(:mocksynapse) do
-    mock_synapse = instance_double(Synapse::Synapse)
-    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
-    allow(mock_synapse).to receive(:available_generators).and_return({
-      'haproxy' => mockgenerator
-    })
-    mock_synapse
-  end
-
   let(:opts) {
     {'method' => 'base'}
   }
 
-  let(:base_watcher_opts) {
-    {'name' => 'test',
-     'discovery' => {
-       'method' => 'base',
-     }}
-  }
-
   let(:watchers) {
     [
-      Synapse::ServiceWatcher::BaseWatcher.new(base_watcher_opts, mocksynapse)
+      instance_double(Synapse::ServiceWatcher::BaseWatcher)
     ]
   }
 

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/service_watcher/base/base'
+
+describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
+  let(:mocksynapse) do
+    mock_synapse = instance_double(Synapse::Synapse)
+    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
+    allow(mock_synapse).to receive(:available_generators).and_return({
+      'haproxy' => mockgenerator
+    })
+    mock_synapse
+  end
+
+  let(:opts) {
+    {'method' => 'base'}
+  }
+
+  let(:base_watcher_opts) {
+    {'name' => 'test',
+     'discovery' => {
+       'method' => 'base',
+     }}
+  }
+
+  let(:watchers) {
+    [
+      Synapse::ServiceWatcher::BaseWatcher.new(base_watcher_opts, mocksynapse)
+    ]
+  }
+
+  subject {
+    Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver.new(opts, watchers)
+  }
+
+  describe "#initialize" do
+    context 'with valid options' do
+      it 'constructs properly' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'with invalid method' do
+      let(:opts) {
+        {'method' => 'bogus'}
+      }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'without watchers' do
+      let(:watchers) {[]}
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#start" do
+    it 'does not raise an error' do
+      expect { subject.start }.not_to raise_error
+    end
+  end
+
+  describe "#stop" do
+    it 'does not raise an error' do
+      expect { subject.stop }.not_to raise_error
+    end
+  end
+
+  describe "#backends" do
+    it 'returns an empty list by default' do
+      expect(subject.backends).to eq([])
+    end
+  end
+
+  describe "#ping?" do
+    it 'returns true by default' do
+      expect(subject.ping?).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
_This PR is stacked on top of #312._

## Summary
A `Resolver` is responsible for providing the abstraction that multiple watchers are one: it decides how to merge the list of `backends` from each one. This PRs adds:
* the interface for the `Resolver`
* a base implementation
* documentation on how to create new `Resolver`s

## Testing
- [x] Unit tests

## Reviewers
@bsherrod @austin-zhu 