### PR TITLE
Add resolver interface and base implementation [stacked on #311]

### DIFF
--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -79,11 +79,11 @@ class Synapse::ServiceWatcher
     end
 
     def ping?
-      return @resolver.ping?
+      return @resolver.healthy?
     end
 
     def backends
-      return @resolver.backends
+      return @resolver.merged_backends
     end
 
     private

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -53,7 +53,7 @@ class Synapse::ServiceWatcher
       end
 
       @resolver = Synapse::ServiceWatcher::Resolver.load_resolver(@discovery['resolver'],
-                                                                  @watchers.values)
+                                                                  @watchers)
     end
 
     def start

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -1,4 +1,5 @@
 require "synapse/service_watcher/base/base"
+require "synapse/service_watcher/multi/resolver"
 require "synapse/log"
 require "synapse/statsd"
 
@@ -48,6 +49,9 @@ class Synapse::ServiceWatcher
 
         @watchers[watcher_name] = watcher
       end
+
+      @resolver = Synapse::ServiceWatcher::Resolver.load_resolver(@discovery['resolver'],
+                                                                  @watchers.values)
     end
 
     def start
@@ -57,6 +61,8 @@ class Synapse::ServiceWatcher
       @watchers.values.each do |w|
         w.start
       end
+
+      @resolver.start
     end
 
     def stop
@@ -66,12 +72,16 @@ class Synapse::ServiceWatcher
       @watchers.values.each do |w|
         w.stop
       end
+
+      @resolver.stop
     end
 
     def ping?
-      @watchers.values.all? do |w|
-        w.ping?
-      end
+      return @resolver.ping?
+    end
+
+    def backends
+      return @resolver.backends
     end
 
     private

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -13,6 +13,8 @@ class Synapse::ServiceWatcher
   #     method, and be of the same format as the method type expects.
   #     (That is, method => zookeeper means a Zookeeper watcher will be created, so
   #     the rest of the options will be passed to the ZookeeperWatcher class).
+  #   resolver => hash. Resolver hash must include method, and be of the same format
+  #     as the method type expects.
   class MultiWatcher < BaseWatcher
     extend Synapse::Logging
     include Synapse::StatsD

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -71,11 +71,11 @@ class Synapse::ServiceWatcher
       log.warn "synapse: multi watcher exiting"
       statsd_increment("synapse.watcher.multi.stop")
 
+      @resolver.stop
+
       @watchers.values.each do |w|
         w.stop
       end
-
-      @resolver.stop
     end
 
     def ping?

--- a/lib/synapse/service_watcher/multi/resolver.rb
+++ b/lib/synapse/service_watcher/multi/resolver.rb
@@ -9,7 +9,7 @@ class Synapse::ServiceWatcher
                    method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Resolver')
                    self.const_get("#{method_class}")
                  rescue Exception => e
-                   raise ArgumentError, "Specified a resolver method of #{method}, which could not be found: #{e}"
+                   raise ArgumentError, "specified a resolver method of #{method}, which could not be found: #{e}"
                  end
 
       return resolver.new(opts, watchers)

--- a/lib/synapse/service_watcher/multi/resolver.rb
+++ b/lib/synapse/service_watcher/multi/resolver.rb
@@ -1,0 +1,18 @@
+class Synapse::ServiceWatcher::MultiWatcher
+  class Resolver
+    def self.load_resolver(opts, watchers)
+      raise ArgumentError, "resolver method not provided" unless opts.has_key?('method')
+      method = opts['method'].downcase
+
+      resolver = begin
+                   require "synapse/service_watcher/multi/resolver/#{method}"
+                   method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Resolver')
+                   self.const_get("#{method_class}")
+                 rescue Exception => e
+                   raise ArgumentError, "Specified a resolver method of #{method}, which could not be found: #{e}"
+                 end
+
+      return resolver.new(opts, watchers)
+    end
+  end
+end

--- a/lib/synapse/service_watcher/multi/resolver.rb
+++ b/lib/synapse/service_watcher/multi/resolver.rb
@@ -1,4 +1,4 @@
-class Synapse::ServiceWatcher::MultiWatcher
+class Synapse::ServiceWatcher
   class Resolver
     def self.load_resolver(opts, watchers)
       raise ArgumentError, "resolver method not provided" unless opts.has_key?('method')

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -21,11 +21,11 @@ class Synapse::ServiceWatcher::MultiWatcher::Resolver
 	     # stop resolver
 	  end
 
-	  def backends
+	  def merged_backends
 	     # return a single list of backends
 	  end
 
-	  def ping?
+	  def healthy?
 	     # return whether or not the watchers are healthy
 	  end
    end

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -1,0 +1,56 @@
+# Resolvers
+
+A resolver decides how to combine, or resolve, multiple service watchers into a
+single result. That is, it operates as a `reducer` function to allow more than
+one service watchers to appear, and act, as a single watcher.
+
+The stub methods listed below should be overridden by any children classes.
+If any additional methods are overridden (such as `initialize`), be sure to
+call `super` first.
+
+```ruby
+require "synapse/service_watcher/multi/resolver/base"
+
+class Synapse::ServiceWatcher::MultiWatcher::Resolver
+   class MyResolver < BaseResolver
+      def start
+	     # start resolver
+	  end
+
+	  def stop
+	     # stop resolver
+	  end
+
+	  def backends
+	     # return a single list of backends
+	  end
+
+	  def ping?
+	     # return whether or not the watchers are healthy
+	  end
+   end
+end
+```
+
+### Resolver Plugin Interface
+Synapse deduces both the class path and class name from the `method` key within
+the resolver configuration.  Every resolver is passed configuration with the
+`method` key, e.g. `zookeeper` or `ec2tag`.
+
+#### Class Location
+Synapse expects to find your class at `synapse/service_watcher/multi/#{method}`.
+You must make your resolver available at that path, and Synapse can "just work" and
+find it.
+
+#### Class Name
+These method strings are then transformed into class names via the following
+function:
+
+```
+method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Resolver')
+```
+
+This has the effect of taking the method, splitting on '_', capitalizing each
+part and recombining with an added 'Resolver' on the end. So `fallback`
+becomes `FallbackResolver`, and `union` becomes `UnionResolver`. Make sure
+your class name is correct.

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -13,6 +13,9 @@ class Synapse::ServiceWatcher::Resolver
 
       raise ArgumentError, "BaseResolver expects method to be base" unless opts['method'] == 'base'
       raise ArgumentError, "no watchers provided" unless watchers.length > 0
+
+      @opts = opts
+      @watchers = watchers
     end
 
     # should be overridden in child classes

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -1,0 +1,38 @@
+require "synapse/log"
+require "synapse/statsd"
+
+class Synapse::ServiceWatcher::MultiWatcher::Resolver
+  class BaseResolver
+    include Synapse::Logging
+    include Synapse::StatsD
+
+    def initialize(opts, watchers)
+      super()
+
+      log.info "creating base resolver"
+
+      raise ArgumentError, "BaseResolver expects method to be base" unless opts['method'] == 'base'
+      raise ArgumentError, "no watchers provided" unless watchers.length > 0
+    end
+
+    # should be overridden in child classes
+    def start
+      log.info "starting base resolver"
+    end
+
+    # should be overridden in child classes
+    def stop
+      log.info "stopping base resolver"
+    end
+
+    # should be overridden in child classes
+    def backends
+      return []
+    end
+
+    # should be overridden in child classes
+    def ping?
+      return true
+    end
+  end
+end

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -29,12 +29,12 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     # should be overridden in child classes
-    def backends
+    def merged_backends
       return []
     end
 
     # should be overridden in child classes
-    def ping?
+    def healthy?
       return true
     end
   end

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -11,7 +11,7 @@ class Synapse::ServiceWatcher::Resolver
 
       log.info "creating base resolver"
 
-      raise ArgumentError, "BaseResolver expects method to be base" unless opts['method'] == 'base'
+      raise ArgumentError, "base resolver expects method to be base" unless opts['method'] == 'base'
       raise ArgumentError, "no watchers provided" unless watchers.length > 0
 
       @opts = opts

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -1,7 +1,7 @@
 require "synapse/log"
 require "synapse/statsd"
 
-class Synapse::ServiceWatcher::MultiWatcher::Resolver
+class Synapse::ServiceWatcher::Resolver
   class BaseResolver
     include Synapse::Logging
     include Synapse::StatsD

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -3,29 +3,13 @@ require 'synapse/service_watcher/multi/resolver/base'
 require 'synapse/service_watcher/base/base'
 
 describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
-  let(:mocksynapse) do
-    mock_synapse = instance_double(Synapse::Synapse)
-    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
-    allow(mock_synapse).to receive(:available_generators).and_return({
-      'haproxy' => mockgenerator
-    })
-    mock_synapse
-  end
-
   let(:opts) {
     {'method' => 'base'}
   }
 
-  let(:base_watcher_opts) {
-    {'name' => 'test',
-     'discovery' => {
-       'method' => 'base',
-     }}
-  }
-
   let(:watchers) {
     [
-      Synapse::ServiceWatcher::BaseWatcher.new(base_watcher_opts, mocksynapse)
+      instance_double(Synapse::ServiceWatcher::BaseWatcher)
     ]
   }
 

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'synapse/service_watcher/multi/resolver/base'
 require 'synapse/service_watcher/base/base'
 
-describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
+describe Synapse::ServiceWatcher::Resolver::BaseResolver do
   let(:opts) {
     {'method' => 'base'}
   }
@@ -14,7 +14,7 @@ describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
   }
 
   subject {
-    Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver.new(opts, watchers)
+    Synapse::ServiceWatcher::Resolver::BaseResolver.new(opts, watchers)
   }
 
   describe "#initialize" do

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -55,15 +55,15 @@ describe Synapse::ServiceWatcher::Resolver::BaseResolver do
     end
   end
 
-  describe "#backends" do
+  describe "#merged_backends" do
     it 'returns an empty list by default' do
-      expect(subject.backends).to eq([])
+      expect(subject.merged_backends).to eq([])
     end
   end
 
-  describe "#ping?" do
+  describe "#healthy?" do
     it 'returns true by default' do
-      expect(subject.ping?).to eq(true)
+      expect(subject.healthy?).to eq(true)
     end
   end
 end

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/service_watcher/base/base'
+
+describe Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver do
+  let(:mocksynapse) do
+    mock_synapse = instance_double(Synapse::Synapse)
+    mockgenerator = Synapse::ConfigGenerator::BaseGenerator.new()
+    allow(mock_synapse).to receive(:available_generators).and_return({
+      'haproxy' => mockgenerator
+    })
+    mock_synapse
+  end
+
+  let(:opts) {
+    {'method' => 'base'}
+  }
+
+  let(:base_watcher_opts) {
+    {'name' => 'test',
+     'discovery' => {
+       'method' => 'base',
+     }}
+  }
+
+  let(:watchers) {
+    [
+      Synapse::ServiceWatcher::BaseWatcher.new(base_watcher_opts, mocksynapse)
+    ]
+  }
+
+  subject {
+    Synapse::ServiceWatcher::MultiWatcher::Resolver::BaseResolver.new(opts, watchers)
+  }
+
+  describe "#initialize" do
+    context 'with valid options' do
+      it 'constructs properly' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'with invalid method' do
+      let(:opts) {
+        {'method' => 'bogus'}
+      }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'without watchers' do
+      let(:watchers) {[]}
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#start" do
+    it 'does not raise an error' do
+      expect { subject.start }.not_to raise_error
+    end
+  end
+
+  describe "#stop" do
+    it 'does not raise an error' do
+      expect { subject.stop }.not_to raise_error
+    end
+  end
+
+  describe "#backends" do
+    it 'returns an empty list by default' do
+      expect(subject.backends).to eq([])
+    end
+  end
+
+  describe "#ping?" do
+    it 'returns true by default' do
+      expect(subject.ping?).to eq(true)
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/loader_spec.rb
+++ b/spec/lib/synapse/multi_resolver/loader_spec.rb
@@ -3,8 +3,8 @@ require 'synapse/service_watcher/base/base'
 require 'synapse/service_watcher/multi/resolver'
 require 'synapse/service_watcher/multi/resolver/base'
 
-describe Synapse::ServiceWatcher::MultiWatcher::Resolver do
-  subject { Synapse::ServiceWatcher::MultiWatcher::Resolver }
+describe Synapse::ServiceWatcher::Resolver do
+  subject { Synapse::ServiceWatcher::Resolver }
 
   let(:watchers) {
     [
@@ -15,7 +15,7 @@ describe Synapse::ServiceWatcher::MultiWatcher::Resolver do
   describe ".load_resolver" do
     let(:config) { {'method' => 'base'} }
     subject {
-      Synapse::ServiceWatcher::MultiWatcher::Resolver
+      Synapse::ServiceWatcher::Resolver
     }
 
     context 'with method => base' do

--- a/spec/lib/synapse/multi_resolver/loader_spec.rb
+++ b/spec/lib/synapse/multi_resolver/loader_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'synapse/service_watcher/base/base'
+require 'synapse/service_watcher/multi/resolver'
+require 'synapse/service_watcher/multi/resolver/base'
+
+describe Synapse::ServiceWatcher::MultiWatcher::Resolver do
+  subject { Synapse::ServiceWatcher::MultiWatcher::Resolver }
+
+  let(:watchers) {
+    [
+      instance_double(Synapse::ServiceWatcher::BaseWatcher)
+    ]
+  }
+
+  describe ".load_resolver" do
+    let(:config) { {'method' => 'base'} }
+    subject {
+      Synapse::ServiceWatcher::MultiWatcher::Resolver
+    }
+
+    context 'with method => base' do
+      it 'creates the base resolver' do
+        expect(subject::BaseResolver).to receive(:new).exactly(:once).with(config, watchers)
+        expect { subject.load_resolver(config, watchers) }.not_to raise_error
+      end
+    end
+
+    context 'with bogus method' do
+      let(:config) { {'method' => 'bogus'} }
+
+      it 'raises an error' do
+        expect(subject::BaseResolver).not_to receive(:new)
+        expect { subject.load_resolver(config, watchers) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -258,6 +258,20 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     end
   end
 
+  describe ".backends" do
+    it "calls resolver.merged_backends" do
+      resolver = subject.instance_variable_get(:@resolver)
+      expect(resolver).to receive(:merged_backends)
+      subject.backends
+    end
+
+    it "returns resolver.merged_backends result" do
+      resolver = subject.instance_variable_get(:@resolver)
+      allow(resolver).to receive(:merged_backends).and_return(["test-a", "test-b"])
+      expect(subject.backends).to eq(["test-a", "test-b"])
+    end
+  end
+
   describe ".ping?" do
     context 'when resolver returns false' do
       it 'returns false' do

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -187,8 +187,8 @@ describe Synapse::ServiceWatcher::MultiWatcher do
         expect(Synapse::ServiceWatcher::Resolver::BaseResolver)
           .to receive(:new)
           .with({'method' => 'base'},
-                [ instance_of(Synapse::ServiceWatcher::ZookeeperWatcher),
-                  instance_of(Synapse::ServiceWatcher::DnsWatcher)])
+                {'primary' => instance_of(Synapse::ServiceWatcher::ZookeeperWatcher),
+                  'secondary' => instance_of(Synapse::ServiceWatcher::DnsWatcher)})
           .and_call_original
 
         expect { subject.new(config, mock_synapse, reconfigure_callback) }.not_to raise_error

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -262,7 +262,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     context 'when resolver returns false' do
       it 'returns false' do
         resolver = subject.instance_variable_get(:@resolver)
-        allow(resolver).to receive(:ping?).and_return(false)
+        allow(resolver).to receive(:healthy?).and_return(false)
 
         expect(subject.ping?).to eq(false)
       end
@@ -271,7 +271,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     context 'when resolver returns true' do
       it 'returns true' do
         resolver = subject.instance_variable_get(:@resolver)
-        allow(resolver).to receive(:ping?).and_return(true)
+        allow(resolver).to receive(:healthy?).and_return(true)
 
         expect(subject.ping?).to eq(true)
       end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -191,7 +191,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
                   instance_of(Synapse::ServiceWatcher::DnsWatcher)])
           .and_call_original
 
-        expect { subject.new(config, mock_synapse) }.not_to raise_error
+        expect { subject.new(config, mock_synapse, reconfigure_callback) }.not_to raise_error
       end
 
       it 'sets @watchers to each watcher' do
@@ -206,7 +206,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
       end
 
       it 'sets @resolver to the requested resolver type' do
-        watcher = subject.new(config, mock_synapse)
+        watcher = subject.new(config, mock_synapse, reconfigure_callback)
         resolver = watcher.instance_variable_get(:@resolver)
 
         expect(resolver).to be_instance_of(Synapse::ServiceWatcher::Resolver::BaseResolver)


### PR DESCRIPTION
_This PR is stacked on top of #311._

## Summary
A `Resolver` is responsible for providing the abstraction that multiple watchers are one: it decides how to merge the list of `backends` from each one. This PRs adds:
* the interface for the `Resolver`
* a base implementation
* documentation on how to create new `Resolver`s
* `MultiWatcher` loads the resolvers

## Testing
- [x] Unit tests

## Reviewers
@bsherrod @austin-zhu 