### PR TITLE
Refactor Zookeeper watcher to support polling in future

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ relevant routing component. For example if you want to only configure HAProxy an
 not NGINX for a particular service, you would pass ``disabled`` to the `nginx` section
 of that service's watcher config.
 
-* [`haproxy`](#haproxysvc): how will the haproxy section for this service be configured. If the corresponding `watcher` is defined to use `zookeeper` and the service publishes its `haproxy` configure on ZK, the `haproxy` hash can be filled/updated via data from the ZK node. 
+* [`haproxy`](#haproxysvc): how will the haproxy section for this service be configured. If the corresponding `watcher` is defined to use `zookeeper` and the service publishes its `haproxy` configure on ZK, the `haproxy` hash can be filled/updated via data from the ZK node.
 * [`nginx`](https://github.com/jolynch/synapse-nginx#service-watcher-config): how will the nginx section for this service be configured. **NOTE** to use this you must have the synapse-nginx [plugin](#plugins) installed.
 
 The services hash may contain the following additional keys:
@@ -259,7 +259,7 @@ Instead of setting Zookeeper watchers, it uses a long-polling method.
 It takes the following mandatory arguments:
 
 * `method`: zookeeper_poll
-* `polling_interval_sec`: the interval at which the watcher will poll Zookeeper.
+* `polling_interval_sec`: the interval at which the watcher will poll Zookeeper. Defaults to 60 seconds.
 
 Other than these two options, it takes the same options as the above ZookeeperWatcher.
 For all the required options, see above.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,19 @@ If the `method` is `serverset` then we expect to find Finagle ServerSet
 (also used by [Aurora](https://github.com/apache/aurora/blob/master/docs/user-guide.md#service-discovery)) registrations with a `serviceEndpoint` and optionally one or more `additionalEndpoints`.
 The Synapse `name` will be automatically deduced from `shard` if present.
 
+##### Zookeeper Poll #####
+
+This watcher retrieves a list of servers and also service config data from zookeeper.
+Instead of setting Zookeeper watchers, it uses a long-polling method.
+
+It takes the following mandatory arguments:
+
+* `method`: zookeeper_poll
+* `polling_interval_sec`: the interval at which the watcher will poll Zookeeper.
+
+Other than these two options, it takes the same options as the above ZookeeperWatcher.
+For all the required options, see above.
+
 ##### Docker #####
 
 This watcher retrieves a list of [docker](http://www.docker.io/) containers via docker's [HTTP API](http://docs.docker.io/en/latest/reference/api/docker_remote_api/).

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -177,8 +177,6 @@ class Synapse::ServiceWatcher
       end
     end
 
-    protected
-
     def validate_discovery_opts
       raise ArgumentError, "invalid discovery method #{@discovery['method']}" \
         unless @discovery['method'] == 'zookeeper'

--- a/lib/synapse/service_watcher/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper.rb
@@ -94,7 +94,7 @@ class Synapse::ServiceWatcher
     private
 
     # find the current backends at the discovery path
-    def discover
+    def discover(zookeeper_opts={:watch => true})
       statsd_increment('synapse.watcher.zk.discovery', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"])
       statsd_time('synapse.watcher.zk.discovery.elapsed_time', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"]) do
         log.info "synapse: discovering backends for service #{@name}"
@@ -103,7 +103,7 @@ class Synapse::ServiceWatcher
         zk_children = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
             statsd_time('synapse.watcher.zk.children.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
               log.info "synapse: zk list children at #{@discovery['path']} for #{attempts} times"
-              @zk.children(@discovery['path'], :watch => true)
+              @zk.children(@discovery['path'], zookeeper_opts)
             end
         end
         statsd_gauge('synapse.watcher.zk.children.bytes', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
@@ -113,8 +113,7 @@ class Synapse::ServiceWatcher
           new_backends << backend unless backend.nil?
         end
 
-        new_config_for_generator = read_config_for_generator
-
+        new_config_for_generator = read_config_for_generator(zookeeper_opts)
         set_backends(new_backends, new_config_for_generator)
       end
     end
@@ -293,7 +292,7 @@ class Synapse::ServiceWatcher
     # the value is "disabled", then skip all zk-based discovery of the
     # generator config (and use the values from the local config.json
     # instead).
-    def read_config_for_generator
+    def read_config_for_generator(zookeeper_opts={:watch => true})
       case @discovery.fetch('generator_config_path', nil)
       when 'disabled'
         discovery_key = nil
@@ -308,7 +307,7 @@ class Synapse::ServiceWatcher
           node = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
             statsd_time('synapse.watcher.zk.get.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
               log.info "synapse: zk get parent at #{@discovery[discovery_key]} for #{attempts} times"
-              @zk.get(@discovery[discovery_key], :watch => true)
+              @zk.get(@discovery[discovery_key], zookeeper_opts)
             end
           end
           new_config_for_generator = parse_service_config(node.first)

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -1,0 +1,77 @@
+require 'synapse/service_watcher/base'
+require 'synapse/service_watcher/zookeeper'
+
+require 'zk'
+require 'thread'
+
+class Synapse::ServiceWatcher
+  class ZookeeperPollWatcher < ZookeeperWatcher
+    def start
+      log.info 'synapse: ZookeeperPollWatcher starting'
+
+      @should_exit = false
+      @thread = nil
+      @poll_interval = @discovery['polling_interval_sec']
+
+      zk_connect do
+        @thread = Thread.new {
+          log.info 'synapse: zookeeper polling thread started'
+
+          # last_run is shifted by a random jitter in order to spread the first
+          # discover call of multiple Synapses. This helps to spread load.
+          # As long as the beginning is spread, the future discovers will also
+          # be spread.
+          last_run = Time.now - rand(@poll_interval)
+
+          until @should_exit
+            now = Time.now
+            elapsed = now - last_run
+
+            if elapsed >= @poll_interval
+              last_run = now
+              discover
+            end
+
+            sleep 0.5
+          end
+
+          log.info 'synapse: zookeeper polling thread exiting normally'
+        }
+      end
+    end
+
+    def stop
+      log.warn 'synapse: ZookeeperPollWatcher stopping'
+
+      zk_teardown do
+        # Signal to the thread that it should exit, and then wait for it to
+        # exit.
+        @should_exit = true
+        @thread.join unless @thread.nil?
+      end
+    end
+
+    private
+
+    def validate_discovery_opts
+      raise ArgumentError, "zookeeper poll watcher expects zookeeper_poll method" unless @discovery['method'] == 'zookeeper_poll'
+      raise ArgumentError, "zookeeper poll watcher expects integer polling_interval_sec >= 0" unless (
+          @discovery.has_key?('polling_interval_sec') &&
+          @discovery['polling_interval_sec'].is_a?(Numeric) &&
+          @discovery['polling_interval_sec'] >= 0
+        )
+      raise ArgumentError, "missing or invalid zookeeper host for service #{@name}" \
+        unless @discovery['hosts']
+      raise ArgumentError, "invalid zookeeper path for service #{@name}" \
+        unless @discovery['path']
+    end
+
+    def discover
+      log.info 'synapse: zookeeper polling discover called'
+      statsd_increment('synapse.watcher.zookeeper_poll.discover')
+
+      # passing {} disables setting watches
+      super({})
+    end
+  end
+end

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -6,6 +6,12 @@ require 'thread'
 
 class Synapse::ServiceWatcher
   class ZookeeperPollWatcher < ZookeeperWatcher
+    def initialize(opts, synapse, reconfigure_callback)
+      super(opts, synapse, reconfigure_callback)
+
+      @discovery['polling_interval_sec'] ||= 60
+    end
+
     def start
       log.info 'synapse: ZookeeperPollWatcher starting'
 
@@ -55,10 +61,10 @@ class Synapse::ServiceWatcher
 
     def validate_discovery_opts
       raise ArgumentError, "zookeeper poll watcher expects zookeeper_poll method" unless @discovery['method'] == 'zookeeper_poll'
-      raise ArgumentError, "zookeeper poll watcher expects integer polling_interval_sec >= 0" unless (
+      raise ArgumentError, "zookeeper poll watcher expects integer polling_interval_sec >= 0" if (
           @discovery.has_key?('polling_interval_sec') &&
-          @discovery['polling_interval_sec'].is_a?(Numeric) &&
-          @discovery['polling_interval_sec'] >= 0
+          !(@discovery['polling_interval_sec'].is_a?(Numeric) &&
+          @discovery['polling_interval_sec'] >= 0)
         )
       raise ArgumentError, "missing or invalid zookeeper host for service #{@name}" \
         unless @discovery['hosts']

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -76,7 +76,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   end
 
   describe 'ZookeeperWatcher' do
-    let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path' } }
+    let(:discovery) { { 'method' => 'zookeeper', 'hosts' => ['somehost'], 'path' => 'some/path' } }
     let(:mock_zk) { double(ZK) }
     let(:mock_node) do
       node_double = double()
@@ -245,6 +245,24 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       end
     end
 
+    describe 'zk_connect' do
+      it 'calls provided block' do
+        allow(ZK).to receive(:new).and_return(mock_zk)
+        allow(mock_zk).to receive(:on_expired_session)
+        allow(mock_zk).to receive(:exists?).and_return(true)
+        allow(subject).to receive(:watch)
+        allow(subject).to receive(:discover)
+
+        expect { |b| subject.send(:zk_connect, &b) }.to yield_control
+      end
+    end
+
+    describe 'zk_teardown' do
+      it 'calls provided block' do
+        expect { |b| subject.send(:zk_teardown, &b) }.to yield_control
+      end
+    end
+
     it 'responds fail to ping? when the client is not in any of the connected/connecting/associatin state' do
       expect(mock_zk).to receive(:associating?).and_return(false)
       expect(mock_zk).to receive(:connecting?).and_return(false)
@@ -289,7 +307,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     end
 
     describe "generator_config_path" do
-      let(:discovery) { { 'method' => 'zookeeper', 'hosts' => 'somehost', 'path' => 'some/path', 'generator_config_path' => generator_config_path } }
+      let(:discovery) { { 'method' => 'zookeeper', 'hosts' => ['somehost'], 'path' => 'some/path', 'generator_config_path' => generator_config_path } }
       before :each do
         expect(subject).to receive(:watch)
         expect(subject).to receive(:discover).and_call_original
@@ -389,7 +407,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   end
 
   describe 'ZookeeperDnsWatcher' do
-    let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => 'somehost','path' => 'some/path' } }
+    let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => ['somehost'],'path' => 'some/path' } }
     let(:message_queue) { [] }
     subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, -> {}, message_queue) }
     it 'decodes data correctly' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -507,6 +507,15 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     end
 
     describe "#initialize" do
+      context 'without polling_interval_sec' do
+        let(:discovery) { { 'method' => 'zookeeper_poll', 'hosts' => ['somehost'], 'path' => 'some/path'} }
+
+        it 'sets a default' do
+          expect { subject }.not_to raise_error
+          expect(subject.instance_variable_get(:@discovery)['polling_interval_sec'].nil?).to be(false)
+        end
+      end
+
       context 'with discovery type != zookeeper_poll' do
         let(:discovery) { { 'method' => 'bogus', 'hosts' => ['somehost'],'path' => 'some/path', 'polling_interval_sec' => 30 } }
 


### PR DESCRIPTION
## Summary
Refactoring out some common code in order to support a separate `ZookeeperPollWatcher` after.
The common code includes:
* Setup/teardown of Zookeeper connections
* Reading child data (path-encoding support / fallback)

`ZookeeperPollWatcher` will be approximately:

```ruby
class ZookeeperPollWatcher < ZookeeperWatcher
   def start
      @stop_watcher = false
      @thread = nil

      zk_connect do
         @thread = Thread.new {
             until @stop_watcher
                 discover
                 sleep some_time
             end
         }
      end
   end

   def stop do
      @stop_watcher = true

      zk_teardown do
          @thread.stop unless @thread.nil?
      end
   end

   def discover
        zk_children = @zk.children(path)
        zk_children.each do |id|
          backend = read_child_data(id)
          new_backends << backend unless backend.nil?
        end

        new_config_for_generator = read_config_for_generator
        set_backends(new_backends, new_config_for_generator)
   end
end
```

## Tests
- [x] unit tests
- [x] manual testing
  * ran integration tests, including for network resilience
  * passes on all scenarios

## Reviewers
@austin-zhu @anson627

Tip: it's easier to review everything except for the commit `8d519b3` first. That commit just moves some functions around, so it's a lot of change but without much impact other than organization.