### PR TITLE
Implement ZookeeperPollWatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,19 @@ If the `method` is `serverset` then we expect to find Finagle ServerSet
 (also used by [Aurora](https://github.com/apache/aurora/blob/master/docs/user-guide.md#service-discovery)) registrations with a `serviceEndpoint` and optionally one or more `additionalEndpoints`.
 The Synapse `name` will be automatically deduced from `shard` if present.
 
+##### Zookeeper Poll #####
+
+This watcher retrieves a list of servers and also service config data from zookeeper.
+Instead of setting Zookeeper watchers, it uses a long-polling method.
+
+It takes the following mandatory arguments:
+
+* `method`: zookeeper_poll
+* `polling_interval_sec`: the interval at which the watcher will poll Zookeeper.
+
+Other than those options, it takes the same options as the above ZookeeperWatcher.
+For all the required options, see above.
+
 ##### Docker #####
 
 This watcher retrieves a list of [docker](http://www.docker.io/) containers via docker's [HTTP API](http://docs.docker.io/en/latest/reference/api/docker_remote_api/).

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ It takes the following mandatory arguments:
 * `method`: zookeeper_poll
 * `polling_interval_sec`: the interval at which the watcher will poll Zookeeper.
 
-Other than those options, it takes the same options as the above ZookeeperWatcher.
+Other than these two options, it takes the same options as the above ZookeeperWatcher.
 For all the required options, see above.
 
 ##### Docker #####

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -1,0 +1,15 @@
+require 'synapse/service_watcher/base'
+require 'synapse/service_watcher/zookeeper'
+
+require 'thread'
+require 'zk'
+
+class Synapse::ServiceWatcher
+  class ZookeeperPollWatcher < ZookeeperWatcher
+
+    private
+    def validate_discovery_opts
+      raise ArgumentError, "zookeeper poll watcher expects zookeeper_poll method" unless @discovery['method'] == 'zookeeper_poll'
+    end
+  end
+end

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -1,15 +1,81 @@
 require 'synapse/service_watcher/base'
 require 'synapse/service_watcher/zookeeper'
 
-require 'thread'
 require 'zk'
+require 'thread'
+require 'timeout'
 
 class Synapse::ServiceWatcher
   class ZookeeperPollWatcher < ZookeeperWatcher
+    def start
+      log.info 'synapse: ZookeeperPollWatcher starting'
+
+      @thread = nil
+      @mutex = Mutex.new
+      @mutex.lock
+
+      zk_connect do
+        @thread = Thread.new {
+          log.info 'synapse: zookeeper polling thread started'
+
+          should_exit = false
+          until should_exit
+            discover
+
+            sleep_duration = @discovery['polling_interval_sec']
+            log.info "synapse: zookeeper polling thread sleeping for #{sleep_duration} seconds"
+
+            # Awake either when
+            # (1) Mutex is released, which occurs in #stop. This means we
+            #     should exit the thread, which will occur on the next
+            #     iteration.
+            # (2) sleep_duration seconds has passed.
+            begin
+              Timeout::timeout(sleep_duration) {
+                mutex.lock
+                should_exit = true
+              }
+            rescue Timeout::Error
+              # do nothing, this just means we should proceed to the next loop
+            end
+          end
+
+          log.info 'synapse: zookeeper polling thread exiting normally'
+        }
+      end
+    end
+
+    def stop
+      log.warn 'synapse: ZookeeperPollWatcher stopping'
+
+      zk_teardown do
+        # Signal to the thread that it should exit, and then wait for it to
+        # exit.
+        @mutex.unlock unless @mutex.nil?
+        @thread.join unless @thread.nil?
+      end
+    end
 
     private
+
     def validate_discovery_opts
       raise ArgumentError, "zookeeper poll watcher expects zookeeper_poll method" unless @discovery['method'] == 'zookeeper_poll'
+      raise ArgumentError, "zookeeper poll watcher expects integer polling_interval_sec >= 0" unless (
+          @discovery.has_key?('polling_interval_sec') &&
+          @discovery['polling_interval_sec'].is_a?(Integer) &&
+          @discovery['polling_interval_sec'] >= 0
+        )
+      raise ArgumentError, "missing or invalid zookeeper host for service #{@name}" \
+        unless @discovery['hosts']
+      raise ArgumentError, "invalid zookeeper path for service #{@name}" \
+        unless @discovery['path']
+    end
+
+    def discover
+      log.info 'synapse: zookeeper polling discover called'
+      statsd_increment('synapse.watcher.zookeeper_poll.discover')
+
+      super(false)
     end
   end
 end

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -32,7 +32,7 @@ class Synapse::ServiceWatcher
             # (2) sleep_duration seconds has passed.
             begin
               Timeout::timeout(sleep_duration) {
-                mutex.lock
+                @mutex.lock
                 should_exit = true
               }
             rescue Timeout::Error

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -28,8 +28,8 @@ class Synapse::ServiceWatcher
             elapsed = now - last_run
 
             if elapsed >= @poll_interval
-              discover
               last_run = now
+              discover
             end
 
             sleep 0.5

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -75,7 +75,8 @@ class Synapse::ServiceWatcher
       log.info 'synapse: zookeeper polling discover called'
       statsd_increment('synapse.watcher.zookeeper_poll.discover')
 
-      super(false)
+      # passing {} disables setting watches
+      super({})
     end
   end
 end

--- a/lib/synapse/service_watcher/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll.rb
@@ -57,7 +57,7 @@ class Synapse::ServiceWatcher
       raise ArgumentError, "zookeeper poll watcher expects zookeeper_poll method" unless @discovery['method'] == 'zookeeper_poll'
       raise ArgumentError, "zookeeper poll watcher expects integer polling_interval_sec >= 0" unless (
           @discovery.has_key?('polling_interval_sec') &&
-          @discovery['polling_interval_sec'].is_a?(Integer) &&
+          @discovery['polling_interval_sec'].is_a?(Numeric) &&
           @discovery['polling_interval_sec'] >= 0
         )
       raise ArgumentError, "missing or invalid zookeeper host for service #{@name}" \

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
+require 'active_support/all'
+require 'active_support/testing/time_helpers'
+
 require 'synapse/service_watcher/zookeeper'
 require 'synapse/service_watcher/zookeeper_dns'
+require 'synapse/service_watcher/zookeeper_poll'
 
 describe Synapse::ServiceWatcher::ZookeeperWatcher do
   let(:mock_synapse) do
@@ -479,6 +483,281 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, mock_synapse, -> {}, message_queue) }
     it 'decodes data correctly' do
       expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
+    end
+  end
+
+  describe Synapse::ServiceWatcher::ZookeeperPollWatcher do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:mock_zk) {
+      zk = double("zookeeper")
+      allow(zk).to receive(:on_expired_session)
+      zk
+    }
+    let(:mock_thread) { double("thread") }
+    let(:discovery) { { 'method' => 'zookeeper_poll', 'hosts' => ['somehost'],'path' => 'some/path', 'polling_interval_sec' => 30 } }
+
+    subject { Synapse::ServiceWatcher::ZookeeperPollWatcher.new(config, mock_synapse, -> {}) }
+
+    after :each do
+      # reset the pool so that doubles are not re-used across instances
+      Synapse::ServiceWatcher::ZookeeperPollWatcher.class_variable_set(:@@zk_pool, {})
+    end
+
+    describe "#initialize" do
+      context 'with discovery type != zookeeper_poll' do
+        let(:discovery) { { 'method' => 'bogus', 'hosts' => ['somehost'],'path' => 'some/path', 'polling_interval_sec' => 30 } }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'with invalid discovery duration' do
+        let(:discovery) { { 'method' => 'zookeeper_poll', 'hosts' => ['somehost'],'path' => 'some/path', 'polling_interval_sec' => 'bogus' } }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'without zookeeper hosts' do
+        let(:discovery) { { 'method' => 'zookeeper_poll', 'path' => 'some/path', 'polling_interval_sec' => 'bogus' } }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'without path set' do
+        let(:discovery) { { 'method' => 'zookeeper_poll', 'hosts' => ['somehost'], 'polling_interval_sec' => 'bogus' } }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    describe '#start' do
+      it 'starts a thread' do
+        expect(Thread).to receive(:new)
+        allow(ZK).to receive(:new).and_return(mock_zk)
+        subject.start
+      end
+
+      it 'connects to zookeeper' do
+        allow(Thread).to receive(:new)
+        expect(ZK)
+          .to receive(:new)
+          .exactly(:once)
+          .with('somehost', :timeout => 5, :thread => :per_callback)
+          .and_return(mock_zk)
+
+        subject.start
+      end
+
+      it 'does not call create' do
+        allow(Thread).to receive(:new)
+        allow(ZK).to receive(:new).and_return(mock_zk)
+
+        expect(mock_zk).not_to receive(:create)
+        subject.start
+      end
+    end
+
+    describe '#stop' do
+      context 'when connected to zookeeper' do
+        before :each do
+          subject.instance_variable_set(:@thread, mock_thread.as_null_object)
+          allow(mock_zk).to receive(:connecting?).and_return(false)
+          allow(mock_zk).to receive(:connected?).and_return(true)
+        end
+
+        it 'disconnects' do
+          allow(ZK).to receive(:new).and_return(mock_zk)
+          allow(Thread).to receive(:new)
+
+          expect(mock_zk).to receive(:close!).exactly(:once)
+          subject.start
+          subject.stop
+        end
+      end
+
+      context 'when not connected to zookeeper' do
+        it 'continues silently' do
+          subject.stop
+        end
+      end
+
+      context 'when thread is running' do
+        before :each do
+          subject.instance_variable_set(:@thread, mock_thread)
+          subject.instance_variable_set(:@zk, mock_zk.as_null_object)
+        end
+
+        it 'kills the thread' do
+          expect(mock_thread).to receive(:join).exactly(:once)
+          subject.stop
+        end
+      end
+
+      context 'when thread is not running' do
+        before :each do
+          subject.instance_variable_set(:@zk, mock_zk.as_null_object)
+        end
+
+        it 'continues silently' do
+          expect { subject.stop }.not_to raise_error
+        end
+      end
+    end
+
+    describe '#ping' do
+      before :each do
+        subject.instance_variable_set(:@zk, mock_zk)
+        allow(mock_zk).to receive(:connecting?).and_return(false)
+        allow(mock_zk).to receive(:associating?).and_return(false)
+        allow(mock_zk).to receive(:connected?).and_return(false)
+      end
+
+      it 'checks zookeeper' do
+        expect(mock_zk).to receive(:connecting?)
+        expect(mock_zk).to receive(:associating?)
+        expect(mock_zk).to receive(:connected?)
+
+        subject.ping?
+      end
+
+      context 'when zookeeper is disconnected' do
+        it 'fails' do
+          expect(subject.ping?).to eq(false)
+        end
+      end
+
+      context 'when zookeeper is connecting' do
+        it 'succeeds' do
+          allow(mock_zk).to receive(:connecting?).and_return(true)
+          expect(subject.ping?).to eq(true)
+        end
+      end
+
+      context 'when zookeeper is connected' do
+        it 'succeeds' do
+          allow(mock_zk).to receive(:connected?).and_return(true)
+          expect(subject.ping?).to eq(true)
+        end
+      end
+
+      context 'when zookeeper is associating' do
+        it 'succeeds' do
+          allow(mock_zk).to receive(:associating?).and_return(true)
+          expect(subject.ping?).to eq(true)
+        end
+      end
+    end
+
+    describe '#discover' do
+      before :each do
+        subject.instance_variable_set(:@zk, mock_zk)
+        allow(mock_zk).to receive(:children).with("some/path", {}).and_return([child_name])
+        allow(mock_zk).to receive(:get).with("some/path", {}).and_return(config_for_generator_string)
+      end
+
+      let(:service_data) {
+        {
+          'name' => 'i-testhost',
+          'host' => '127.0.0.1',
+          'port' => '3001',
+          'labels' => {
+            'region' => 'us-east-1',
+            'az' => 'us-east-1a'
+          }
+        }
+      }
+      let(:mock_node) do
+        node_double = double()
+        allow(node_double).to receive(:first).and_return(service_data_string)
+        node_double
+      end
+
+      let(:backend) {
+        service_data.merge({"id" => kind_of(Numeric), "weight" => nil, "haproxy_server_options" => nil})
+      }
+
+      let(:encoded_str) { Base64.urlsafe_encode64(JSON(service_data)) }
+      let(:child_name) { "base64_#{encoded_str.length}_#{encoded_str}_0000000003" }
+
+      context "with path encoding" do
+        context "with sequential node" do
+          it "does not call get on child" do
+            expect(mock_zk).not_to receive(:get).with(start_with("some/path/"))
+            subject.send(:discover)
+          end
+
+          it 'sets backends with the parsed data' do
+            expect(subject).to receive(:set_backends).exactly(:once).with([backend], parsed_config_for_generator)
+            subject.send(:discover)
+          end
+        end
+
+        context "with non-sequential node" do
+          let(:child_name) { "base64_#{encoded_str.length}_#{encoded_str}" }
+
+          it "does not call get on child" do
+            expect(mock_zk).not_to receive(:get).with(start_with("some/path/"))
+            subject.send(:discover)
+          end
+
+          it 'sets backends with the parsed data' do
+            expect(subject).to receive(:set_backends).exactly(:once).with(
+                                 [backend.merge({"id" => nil})], parsed_config_for_generator)
+            subject.send(:discover)
+          end
+        end
+      end
+
+      context "without path encoding" do
+        let(:child_name) { "child_1" }
+
+        it "sets backends with the fetched data" do
+          expect(mock_zk).to receive(:get).with("some/path/child_1").and_return(mock_node)
+          expect(subject).to receive(:set_backends).exactly(:once).with([backend], parsed_config_for_generator)
+          subject.send(:discover)
+        end
+      end
+
+      describe "retry_policy" do
+        before :each do
+          subject.instance_variable_set(:@retry_policy, {'max_attempts' => 2, 'base_interval' => 0, 'max_interval' => 0})
+        end
+
+        context 'with retriable errors' do
+          before :each do
+            allow(mock_zk).to receive(:register)
+            allow(mock_zk).to receive(:exists?).with('some/path', {:watch=>true}).once.and_raise(ZK::Exceptions::ConnectionLoss)
+            allow(mock_zk).to receive(:exists?).with('some/path', {:watch=>true}).once.and_return(true)
+            allow(mock_zk).to receive(:children).with('some/path', {:watch=>true}).once.and_raise(ZK::Exceptions::OperationTimeOut)
+            allow(mock_zk).to receive(:children).with('some/path', {:watch=>true}).once.and_return(["test_child_1"])
+            allow(mock_zk).to receive(:get).with('some/path', {:watch=>true}).once.and_raise(::Zookeeper::Exceptions::ContinuationTimeoutError)
+            allow(mock_zk).to receive(:get).with('some/path', {:watch=>true}).once.and_return(config_for_generator_string)
+            allow(mock_zk).to receive(:get).with('some/path/test_child_1').once.and_raise(::Zookeeper::Exceptions::NotConnected)
+            allow(mock_zk).to receive(:get).with('some/path/test_child_1').once.and_return(mock_node)
+            subject.instance_variable_set('@zk', mock_zk)
+          end
+
+          it 'retries until success' do
+            expect { subject.send(:discover) }.not_to raise_error
+          end
+
+          it 'calls set_backends' do
+            expect(subject)
+              .to receive(:set_backends)
+              .with([service_data.merge({'id' => kind_of(Numeric), 'haproxy_server_options' => nil, "weight" => nil})],
+                    parsed_config_for_generator)
+            subject.send(:discover)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -491,8 +491,6 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
   end
 
   describe Synapse::ServiceWatcher::ZookeeperPollWatcher do
-    include ActiveSupport::Testing::TimeHelpers
-
     let(:mock_zk) {
       zk = double("zookeeper")
       allow(zk).to receive(:on_expired_session)

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -250,6 +250,10 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     end
 
     describe 'zk_connect' do
+      before :each do
+        Synapse::ServiceWatcher::ZookeeperWatcher.class_variable_set(:@@zk_pool, {})
+      end
+
       it 'calls provided block' do
         allow(ZK).to receive(:new).and_return(mock_zk)
         allow(mock_zk).to receive(:on_expired_session)

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -523,6 +523,14 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         end
       end
 
+      context 'with float discovery duration' do
+        let(:discovery) { { 'method' => 'zookeeper_poll', 'hosts' => ['somehost'],'path' => 'some/path', 'polling_interval_sec' => 2.5 } }
+
+        it 'constructs properly' do
+          expect { subject }.not_to raise_error
+        end
+      end
+
       context 'without zookeeper hosts' do
         let(:discovery) { { 'method' => 'zookeeper_poll', 'path' => 'some/path', 'polling_interval_sec' => 'bogus' } }
 

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -499,7 +499,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
 
     subject { Synapse::ServiceWatcher::ZookeeperPollWatcher.new(config, mock_synapse, -> {}) }
 
-    after :each do
+    before :each do
       # reset the pool so that doubles are not re-used across instances
       Synapse::ServiceWatcher::ZookeeperPollWatcher.class_variable_set(:@@zk_pool, {})
     end


### PR DESCRIPTION
_This PR is stacked on top of #315._

## Summary
Implement the `ZookeeperPollWatcher` watcher type, which uses long-polling instead of Zookeeper watches. The polling interval can be configured. The polling runs in a background thread that is interruptible.

## Progress
- [x] tests
- [x] implementation
- [x] documentation

## Tests
- [x] unit tests
- [x] integration tests for existing `ZookeeperWatcher`
- [x] integration tests  for new `ZookeeperPollWatcher`
- [x] Polling working:
```
I, [2020-03-06T15:39:36.212292 #20523]  INFO -- Module: synapse: configuring statsd on host 'localhost' port 8125
I, [2020-03-06T15:39:36.269757 #20523]  INFO -- Synapse::Synapse: synapse: starting...
...
I, [2020-03-06T15:39:36.275504 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling thread started
I, [2020-03-06T15:39:36.275572 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling discover called
...
I, [2020-03-06T15:39:36.276002 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zk list children at /synapse-test/services for 1 times
I, [2020-03-06T15:39:36.277309 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zk get parent at /synapse-test/services for 1 times
I, [2020-03-06T15:39:36.277813 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: discovered 1 backends for service synapse-test
I, [2020-03-06T15:39:36.277834 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: discovered config_for_generator for service synapse-test
I, [2020-03-06T15:39:36.278071 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling thread sleeping for 5 seconds
...
I, [2020-03-06T15:39:41.282646 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling discover called
I, [2020-03-06T15:39:41.282803 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: discovering backends for service synapse-test
...
I, [2020-03-06T15:39:41.285947 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling thread sleeping for 5 seconds
I, [2020-03-06T15:39:46.290359 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling discover called
```
- [x] Polling reads new backends which are reflected in HAProxy config file
```
$ cat haproxy.cfg | grep server
        timeout  server  1m
        option http-server-close
        server i-host1_127.0.0.1:26009 127.0.0.1:26009 id 1 cookie i-host1_127.0.0.1:26009 check port 26009 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /some/path crt /some/other/path

# add new server
$ zookeepercli --servers localhost:2181 -c create /synapse-test/services/0002.mango-test '{"host":"127.0.0.2","port":26010,"name":"i-host2","labels":{"region":"us-east-1","az":"us-east-1b"}}'
$ cat haproxy.cfg | grep server
        timeout  server  1m
        option http-server-close
        server i-host2_127.0.0.2:26010 127.0.0.2:26010 id 2 cookie i-host2_127.0.0.2:26010 check port 26010 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /some/path crt /some/path
        server i-host1_127.0.0.1:26009 127.0.0.1:26009 id 1 cookie i-host1_127.0.0.1:26009 check port 26009 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /some/path crt /some/path

# remove a server
$ zookeepercli --servers localhost:2181 -c rm /synapse-test/services/0001.mango-test
$ cat haproxy.cfg | grep server        timeout  server  1m
        option http-server-close
        server i-host2_127.0.0.2:26010 127.0.0.2:26010 id 2 cookie i-host2_127.0.0.2:26010 check port 26010 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file /some/path crt /some/path
```
- [x] Killing Synapse process exits immediately:
```
I, [2020-03-06T15:40:16.336884 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling thread sleeping for 5 seconds
W, [2020-03-06T15:40:18.269418 #20523]  WARN -- Synapse::Synapse: synapse: exiting; sending stop signal to all watchers
W, [2020-03-06T15:40:18.269509 #20523]  WARN -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: ZookeeperPollWatcher stopping
I, [2020-03-06T15:40:18.269541 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper watcher cleaning up
I, [2020-03-06T15:40:18.269647 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper polling thread exiting normally
I, [2020-03-06T15:40:18.269746 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: closing zk connection to localhost:3181,localhost:3182,localhost:3183,localhost:3184,localhost:3185
I, [2020-03-06T15:40:18.270762 #20523]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: zookeeper watcher cleaned up successfully
```

## Reviewers
@austin-zhu @anson627 @bsherrod 