### PR TITLE
Implement S3 toggle resolver

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -1,5 +1,7 @@
 require 'logger'
 require 'json'
+require 'uri'
+require 'aws-sdk'
 
 require 'synapse/version'
 require 'synapse/log'
@@ -16,6 +18,15 @@ module Synapse
 
     def initialize(opts={})
       StatsD.configure_statsd(opts["statsd"] || {})
+
+      # configure AWS clients to use custom endpoint
+      if ENV.has_key?('AWS_ENDPOINT_URL')
+        aws_endpoint = URI(ENV['AWS_ENDPOINT_URL'])
+        AWS.config(s3_endpoint: aws_endpoint.host,
+                   s3_port: aws_endpoint.port,
+                   s3_force_path_style: true,
+                   use_ssl: aws_endpoint.scheme == 'https')
+      end
 
       # create objects that need to be notified of service changes
       @config_generators = create_config_generators(opts)

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -1,5 +1,6 @@
 require "synapse/service_watcher/base/base"
 require "synapse/service_watcher/multi/resolver"
+
 require "synapse/log"
 require "synapse/statsd"
 

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -13,6 +13,10 @@ require "synapse/service_watcher/multi/resolver/base"
 
 class Synapse::ServiceWatcher::MultiWatcher::Resolver
    class MyResolver < BaseResolver
+	  def validate_opts
+	     # validate options in @opts and optionally, wathchers in @watchers
+	  end
+
       def start
 	     # start resolver
 	  end

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -11,11 +11,14 @@ class Synapse::ServiceWatcher::Resolver
 
       log.info "creating base resolver"
 
-      raise ArgumentError, "base resolver expects method to be base" unless opts['method'] == 'base'
-      raise ArgumentError, "no watchers provided" unless watchers.length > 0
-
       @opts = opts
       @watchers = watchers
+      validate_opts
+    end
+
+    def validate_opts
+      raise ArgumentError, "base resolver expects method to be base" unless @opts['method'] == 'base'
+      raise ArgumentError, "no watchers provided" unless @watchers.length > 0
     end
 
     # should be overridden in child classes

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -14,6 +14,8 @@ class Synapse::ServiceWatcher::Resolver
     include Synapse::StatsD
     include Synapse::RetryPolicy
 
+    DEFAULT_WATCHER = 'primary'
+
     @@S3_RETRY_POLICY = {
       'max_attempts' => 3,
       'base_interval' => 10,
@@ -29,7 +31,7 @@ class Synapse::ServiceWatcher::Resolver
       super(opts, watchers)
 
       @watcher_mu = Mutex.new
-      @watcher_setting = 'primary'
+      @watcher_setting = DEFAULT_WATCHER
       @last_watcher_weights_hash = nil
 
       @polling_interval = @opts['s3_polling_interval_seconds']
@@ -153,7 +155,7 @@ class Synapse::ServiceWatcher::Resolver
           log.warn "synapse: s3 toggle: failed to pick a watcher"
           statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:fail', 'reason:no_choice'])
 
-          'primary'
+          DEFAULT_WATCHER
         else
           log.info "synapse: s3 toggle: chose watcher #{chosen_watcher}"
           statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:success', "watcher:#{chosen_watcher}"])
@@ -163,7 +165,7 @@ class Synapse::ServiceWatcher::Resolver
         log.warn "synapse: s3 toggle: no watchers read, defaulting to primary"
         statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:fail', 'reason:watchers_missing'])
 
-        'primary'
+        DEFAULT_WATCHER
       end
 
       return watcher_name

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -147,6 +147,8 @@ class Synapse::ServiceWatcher::Resolver
       @watcher_mu.synchronize {
         @watcher_setting = watcher_name
       }
+
+      return watcher_name
     end
 
     def read_s3_file

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -52,7 +52,7 @@ class Synapse::ServiceWatcher::Resolver
           if elapsed >= @polling_interval
             log.info "synapse: s3 resolver reading from s3"
             config_from_s3 = read_s3_file
-            set_watcher(config_from_s3)
+            stable_set_watcher(config_from_s3)
 
             last_run = now
           end
@@ -96,6 +96,10 @@ class Synapse::ServiceWatcher::Resolver
       @watcher_mu.synchronize {
         return @watcher_setting
       }
+    end
+
+    def stable_set_watcher(watcher_weights)
+      return set_watcher(watcher_weights)
     end
 
     def set_watcher(watcher_weights)

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -172,12 +172,12 @@ class Synapse::ServiceWatcher::Resolver
 
       data =
         begin
-          resp = s3.get_object(bucket: @s3_bucket, key: @s3_path)
-          parsed = YAML.load(resp.body.read)
+          resp = s3.get_object(bucket_name: @s3_bucket, key: @s3_path)
+          parsed = YAML.load(resp.data[:data])
 
           log.info "synapse: s3 toggle resolver: read s3 file: #{parsed}"
           parsed
-        rescue Psych::SyntaxError => e
+        rescue Psych::SyntaxError, TypeError => e
           log.warn "synapse: s3 toggle resolver: failed to parse s3 file: #{e}"
           statsd_increment('synapse.watcher.multi.resolver.s3_toggle.fetch_failure', ["reason:parse_error"])
           nil

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -27,7 +27,7 @@ class Synapse::ServiceWatcher::Resolver
     # is for the watcher to get chosen.
     DEFAULT_WATCHER = 'primary'.freeze
 
-    @@S3_CLIENT = AWS::S3::Client.new
+    @@s3_client = AWS::S3::Client.new
 
     def initialize(opts, watchers)
       super(opts, watchers)
@@ -183,7 +183,7 @@ class Synapse::ServiceWatcher::Resolver
     def read_s3_file
       data =
         begin
-          resp = @@S3_CLIENT.get_object(bucket_name: @s3_bucket, key: @s3_path)
+          resp = @@s3_client.get_object(bucket_name: @s3_bucket, key: @s3_path)
           parsed = YAML.load(resp.data[:data])
 
           log.info "synapse: s3 toggle resolver: read s3 file: #{parsed}"

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -1,0 +1,173 @@
+require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/log'
+require 'synapse/statsd'
+require 'synapse/retry_policy'
+
+require 'aws-sdk'
+require 'timeout'
+require 'thread'
+require 'json'
+
+class Synapse::ServiceWatcher::Resolver
+  class S3ToggleResolver < BaseResolver
+    include Synapse::Logging
+    include Synapse::StatsD
+    include Synapse::RetryPolicy
+
+    @@S3_RETRY_POLICY = {
+      'max_attempts' => 3,
+      'base_interval' => 10,
+      'max_interval' => 180,
+      'retriable_errors' => [
+        # S3 errors are not included here because the S3 client already includes
+        # retrying logic.
+        JSON::ParserError,
+      ]
+    }
+
+    def initialize(opts, watchers)
+      super(opts, watchers)
+
+      @watcher_mu = Mutex.new
+      @watcher_setting = 'primary'
+      @polling_interval = @opts['s3_polling_interval_seconds']
+
+      s3_parts = parse_s3_url(@opts['s3_url'])
+      @s3_bucket = s3_parts['bucket']
+      @s3_path = s3_parts['path']
+    end
+
+    def start
+      log.info "synapse: start s3 toggle resolver"
+
+      @should_exit = false
+      @thread = Thread.new {
+        log.info "synapse: s3 toggle resolver background thread starting"
+        last_run = Time.now - rand(@polling_interval)
+
+        until @should_exit
+          now = Time.now
+          elapsed = now - last_run
+
+          if elapsed >= @polling_interval
+            log.info "synapse: s3 resolver reading from s3"
+            config_from_s3 = read_s3_file
+            set_watcher(config_from_s3)
+
+            last_run = now
+          end
+
+          sleep 0.5
+        end
+
+        log.info "synapse: s3 toggle resolver background thread exiting normally"
+      }
+    end
+
+    def stop
+      @should_exit = true
+      @thread.join unless @thread.nil?
+    end
+
+    def merged_backends
+      watcher_name = get_watcher
+      return @watchers[watcher_name].backends
+    end
+
+    def healthy?
+      watcher_name = get_watcher
+      return @watchers[watcher_name].ping?
+    end
+
+    def validate_opts
+      %w(method s3_url s3_polling_interval_seconds).each do |opt|
+        raise ArgumentError, "s3 toggle resolver expects option #{opt}" unless @opts.has_key?(opt)
+      end
+
+      raise ArgumentError, "s3 toggle resolver expects method to be s3_toggle" unless @opts['method'] == 's3_toggle'
+      raise ArgumentError, "s3 url should be of form s3://{bucket}/{name}" unless @opts['s3_url'].start_with?('s3://')
+      raise ArgumentError, "s3 toggle resolver expects numeric s3_polling_interval_seconds" unless @opts['s3_polling_interval_seconds'].is_a?(Numeric)
+      raise ArgumentError, "s3 toggle resolver expects at least 1 watcher" unless @watchers.length > 0
+    end
+
+    private
+
+    def get_watcher
+      @watcher_mu.synchronize {
+        return @watcher_setting
+      }
+    end
+
+    def set_watcher(watcher_weights)
+      watcher_name = if !watcher_weights.nil? && watcher_weights.length > 0
+        total_weight = watcher_weights.values.inject(:+)
+        pick = rand(total_weight)
+        chosen_watcher = nil
+
+        watcher_weights.each do |key, value|
+          if pick < value
+            chosen_watcher = key
+            break
+          else
+            pick -= value
+          end
+
+          log.info "synapse: s3 toggle: chose watcher #{chosen_watcher}"
+          statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switched_watcher', ["watcher:#{chosen_watcher}"])
+          chosen_watcher
+        end
+      else
+        log.warn "synapse: s3 toggle: no watchers read, defaulting to primary"
+        statsd_increment('synapse.watcher.multi.resolver.s3_toggle.watchers_missing')
+
+        'primary'
+      end
+
+      @watcher_mu.synchronize {
+        @watcher_setting = watcher_name
+      }
+    end
+
+    def read_s3_file
+      s3 = AWS::S3::Client.new
+
+      data =
+        begin
+          with_retry(@@S3_RETRY_POLICY) do |attempts|
+            log.info "synapse: reading s3 toggle file for #{attempts} times"
+
+            resp = s3.get_object(bucket: @s3_bucket, key: @s3_path)
+            parsed = JSON.parse(resp.body.read)
+
+            log.info "synapse: read s3 toggle file: #{parsed}"
+            parsed
+          end
+        rescue JSON::ParserError => e
+          log.warn "synapse: failed to parse s3 toggle file: #{e}"
+          statsd_increment('synapse.watcher.multi.resolver.s3_toggle.fetch_failure', ["reason:parse_error"])
+          {}
+        rescue AWS::Errors::Base => e
+          log.warn "synapse: failed to fetch s3 toggle file: #{e}"
+          statsd_increment('synapse.watcher.multi.resolver.s3_toggle.fetch_failure', ["reason:s3_error"])
+          {}
+        end
+
+      return data
+    end
+
+    # url = s3://{bucket}/{path}
+    def parse_s3_url(url)
+      parts = url.partition('s3://')
+      raise ArgumentError, "expected url to begin with 's3://' prefix: #{url}" unless parts.length == 3
+
+      bucket, path = parts[2].split('/', 2)
+      raise ArgumentError, "expected url to be of format s3://{bucket}/{key}" unless (
+          !bucket.nil? &&
+          !path.nil? &&
+          bucket.length > 0 &&
+          path.length > 0)
+
+      return {'bucket' => bucket, 'path' => path}
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -186,16 +186,14 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
     end
 
     it 'picks between the watchers by weight' do
-      subject.send(:set_watcher, {'primary' => 25, 'secondary' => 75})
-      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
+      expect(subject.send(:set_watcher, {'primary' => 25, 'secondary' => 75})).to eq('secondary')
     end
 
     context 'when primary has all weight' do
       let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
 
       it 'returns primary' do
-        subject.send(:set_watcher, watcher_weights)
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
+        expect(subject.send(:set_watcher, watcher_weights)).to eq('primary')
       end
     end
 
@@ -208,9 +206,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
         # Explicitly set the setting to something that cannot occur.
         # However, it should not change because the weights do not change.
         subject.instance_variable_set(:@watcher_setting, 'mock-watcher')
-        subject.send(:set_watcher, watcher_weights)
-
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('mock-watcher')
+        expect(subject.send(:set_watcher, watcher_weights)).to eq('mock-watcher')
       end
     end
 
@@ -218,8 +214,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       let(:watcher_weights) {}
 
       it 'returns primary' do
-        subject.send(:set_watcher, watcher_weights)
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
+        expect(subject.send(:set_watcher, watcher_weights)).to eq('primary')
       end
     end
 
@@ -227,8 +222,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       let(:watcher_weights) { {'primary' => 50, 'secondary' => 100} }
 
       it 'still sets watcher properly' do
-        subject.send(:set_watcher, watcher_weights)
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
+        expect(subject.send(:set_watcher, watcher_weights)).to eq('secondary')
       end
     end
   end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -181,21 +181,21 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
     let(:watcher_weights) { {'primary' => 0, 'secondary' => 100} }
 
     it 'sets @watcher_setting' do
-      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
       subject.send(:set_watcher, watcher_weights)
+      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
     end
 
     it 'picks between the watchers by weight' do
-      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
       subject.send(:set_watcher, {'primary' => 25, 'secondary' => 75})
+      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
     end
 
     context 'when primary has all weight' do
       let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
 
       it 'returns primary' do
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
         subject.send(:set_watcher, watcher_weights)
+        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
       end
     end
 
@@ -203,13 +203,14 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       let(:watcher_weights) { {'primary' => 50, 'secondary' => 50} }
 
       it 'deterministically returns the same result' do
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('mock-watcher')
         subject.send(:set_watcher, watcher_weights)
 
         # Explicitly set the setting to something that cannot occur.
         # However, it should not change because the weights do not change.
         subject.instance_variable_set(:@watcher_setting, 'mock-watcher')
         subject.send(:set_watcher, watcher_weights)
+
+        expect(subject.instance_variable_get(:@watcher_setting)).to eq('mock-watcher')
       end
     end
 
@@ -217,8 +218,8 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       let(:watcher_weights) {}
 
       it 'returns primary' do
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
         subject.send(:set_watcher, watcher_weights)
+        expect(subject.instance_variable_get(:@watcher_setting)).to eq('primary')
       end
     end
 
@@ -226,8 +227,8 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       let(:watcher_weights) { {'primary' => 50, 'secondary' => 100} }
 
       it 'still sets watcher properly' do
-        expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
         subject.send(:set_watcher, watcher_weights)
+        expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
       end
     end
   end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -234,6 +234,26 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
         expect(results['secondary']).to be > results['primary']
       end
     end
+
+    context 'with unknown watcher' do
+      let(:watcher_weights) { {'primary' => 0, 'secondary' => 1, 'bogus' => 100000} }
+
+      it 'ignores unknown watchers' do
+        (0..100).each do
+          expect(subject.send(:pick_watcher, watcher_weights)).to eq('secondary')
+        end
+      end
+    end
+
+    context 'with only unknown watchers' do
+      let(:watcher_weights) { {'bogus' => 10000} }
+
+      it 'always picks primary' do
+        (0..100).each do
+          expect(subject.send(:pick_watcher, watcher_weights)).to eq('primary')
+        end
+      end
+    end
   end
 
   describe 'set_watcher' do

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -1,0 +1,254 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi/resolver/s3_toggle'
+require 'synapse/service_watcher/base/base'
+
+describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
+  let(:watchers) { {'primary' => primary_watcher, 'secondary' => secondary_watcher} }
+
+  let(:primary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends).and_return(primary_backends)
+    allow(w).to receive(:ping?).and_return(true)
+    w
+  }
+  let(:primary_backends) { ["primary_1", "primary_2", "primary_3"] }
+
+  let(:secondary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends).and_return(secondary_backends)
+    allow(w).to receive(:ping?).and_return(true)
+    w
+  }
+  let(:secondary_backends) { ["secondary_1", "secondary_2", "secondary_3"] }
+
+  let(:opts) { opts_valid }
+  let(:opts_valid) {
+    {'method' => 's3_toggle',
+       's3_url' => 's3://bucket/path1/path2',
+       's3_polling_interval_seconds' => 60}
+  }
+
+  subject { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts, watchers) }
+
+  describe '#initialize' do
+    context 'with valid arguments' do
+      it 'constructs normally' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'with invalid arguments' do
+      context 'with invalid method' do
+        let(:opts) { opts_valid.merge({'method' => 'bogus'}) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'with invalid s3_url' do
+        let(:opts) { opts_valid.merge({'s3_url' => 'bogus'}) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'with invalid s3_polling_interval_seconds' do
+        let(:opts) { opts_valid.merge({'s3_polling_interval_seconds' => 'bogus'}) }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      %w(method s3_url s3_polling_interval_seconds).each do |opt|
+        context "missing #{opt}" do
+          let(:opts) {
+            opts_valid.delete(opt)
+            opts_valid
+          }
+
+          it 'raises an error' do
+            expect { subject }.to raise_error(ArgumentError)
+          end
+        end
+      end
+
+      context 'without watchers' do
+        let(:watchers) { [] }
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
+
+  describe '#start' do
+    it 'starts a thread' do
+      expect(Thread).to receive(:new)
+    end
+
+    it 'calls #set_watcher' do
+      allow(Thread).to receive(:new) do |&block|
+        block.call
+      end
+
+      expect(subject).to receive(:read_s3_file)
+      expect(subject).to receive(:set_watcher)
+      subject.start
+    end
+  end
+
+  describe '#stop' do
+    context 'with a thread running' do
+      let(:mock_thread) {
+        thr = double(Thread)
+        allow(Thread).to receive(:new).and_return(thr)
+        thr
+      }
+
+      it 'waits to exit' do
+        expect(mock_thread).to receive(:join)
+        subject.stop
+      end
+    end
+
+    context 'without a thread running' do
+      it 'continues silently' do
+        subject.stop
+      end
+    end
+  end
+
+  describe '#merged_backends' do
+    before :each do
+      subject.instance_variable_set(:@watcher_setting, 'secondary')
+    end
+
+    it 'calls #backends on current watcher' do
+      expect(secondary_watcher).to receive(:backends)
+      subject.merged_backends
+    end
+
+    it 'does not call #backends on other watchers' do
+      expect(primary_watcher).not_to receive(:backends)
+      subject.merged_backends
+    end
+
+    it 'returns backends from current watcher' do
+      expect(subject.merged_backends).to eq(secondary_backends)
+    end
+  end
+
+  describe '#healthy?' do
+    before :each do
+      subject.instance_variable_set(:@watcher_setting, 'secondary')
+    end
+
+    it 'calls #ping? on current watcher' do
+      expect(secondary_watcher).to receive(:ping?)
+      subject.healthy?
+    end
+
+    it 'does not call #ping? on other watchers' do
+      expect(primary_watcher).not_to receive(:ping?)
+      subject.healthy?
+    end
+
+    context 'when current watcher returns true' do
+      before :each do
+        allow(secondary_watcher).to receive(:ping?).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+    end
+
+    context 'when current watcher returns false' do
+      before :each do
+        allow(secondary_watcher).to receive(:ping?).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(subject.healthy?).to eq(false)
+      end
+    end
+
+    context 'when other watchers return unhealthy' do
+      before :each do
+        allow(secondary_watcher).to receive(:ping?).and_return(true)
+        allow(primary_watcher).to receive(:ping?).and_return(false)
+      end
+
+      it 'still returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+    end
+  end
+
+  describe 'set_watcher' do
+    let(:watcher_weights) { {'primary' => 0, 'secondary' => 100} }
+
+    it 'sets @watcher_setting' do
+      expect(subject).instance_variable_get(:@watcher_setting, 'secondary')
+      subject.set_watcher(watcher_weights)
+    end
+
+    it 'picks between the watchers by weight'
+
+    context 'when primary has all weight' do
+      let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
+
+      it 'returns primary' do
+        expect(subject).instance_variable_get(:@watcher_setting, 'primary')
+        subject.set_watcher(watcher_weights)
+      end
+    end
+
+    context 'when called multiple times' do
+      let(:watcher_weights) { {'primary' => 50, 'secondary' => 50} }
+
+      it 'deterministically returns the same result' do
+        expect(subject).instance_variable_get(:@watcher_setting, 'primary')
+        subject.set_watcher(watcher_weights)
+      end
+    end
+
+    context 'when weights are empty' do
+      let(:watcher_weights) {}
+
+      it 'returns primary' do
+        expect(subject).instance_variable_get(:@watcher_setting, 'primary')
+        subject.set_watcher(watcher_weights)
+      end
+    end
+
+    context 'when weights add up to more than 100' do
+      let(:watcher_weights) { {'primary' => 50, 'secondary' => 100} }
+
+      it 'still sets watcher properly'
+    end
+  end
+
+  describe 'read_s3_file' do
+    let(:s3_data) { {'primary' => 50, 'secondary' => 50} }
+
+    it 'properly parses response'
+    it 'calls S3 API with proper bucket and key'
+
+    context 'with s3 errors' do
+      it 'retries'
+      it 'exponentially backs off'
+    end
+  end
+
+  describe 'parse_s3_url' do
+    it 'returns components'
+
+    context 'with invalid format' do
+      it 'raises an error'
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -298,7 +298,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
   describe 'read_s3_file' do
     let(:s3_data) { {'primary' => 50, 'secondary' => 50} }
-    let(:s3_data_string) { JSON.dump(s3_data) }
+    let(:s3_data_string) { YAML.dump(s3_data) }
     let(:mock_s3_response) {
       mock_response = double("mock_s3_response")
       allow(mock_response).to receive(:body).and_return(StringIO.new(s3_data_string))
@@ -337,8 +337,8 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
       end
     end
 
-    context 'with invalid json' do
-      let(:s3_data_string) { "bogus-json" }
+    context 'with invalid yaml' do
+      let(:s3_data_string) { "{" }
 
       it 'retries' do
         expect(mock_s3).to receive(:get_object).exactly(3).and_return(mock_s3_response)


### PR DESCRIPTION
## Summary
Implement the S3 toggle resolver, which periodically polls an S3 file for a map of `watcher name --> weight`. This map is used to randomly pick a watcher to use.

## Tests
- [x] unit tests
- [x] resolver runs background thread
```
I, [2020-03-12T12:34:41.783884 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>100, "secondary"=>0}
I, [2020-03-12T12:34:41.783950 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: chose watcher primary
I, [2020-03-12T12:34:51.857979 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>100, "secondary"=>0}
I, [2020-03-12T12:34:51.858024 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update
I, [2020-03-12T12:35:01.933505 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>100, "secondary"=>0}
I, [2020-03-12T12:35:01.933549 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update
I, [2020-03-12T12:35:12.000301 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>100, "secondary"=>0}
I, [2020-03-12T12:35:12.000347 #74406]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update
```

- [x] resolver defaults to primary
```bash
# must be run before starting Synapse
$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 rm s3://synapse-test/s3-toggle-resolver.yaml
```

*Log*:
```
W, [2020-03-12T12:49:05.435594 #2462]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: failed to fetch s3 file: No Such Key
W, [2020-03-12T12:49:05.435724 #2462]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: s3 file has invalid schema
W, [2020-03-12T12:49:05.435782 #2462]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: received nil watcher weights, not picking
I, [2020-03-12T12:49:05.435832 #2462]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: current watcher: primary
```
- [x] reads from S3
```
I, [2020-03-12T12:40:15.954471 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
```
- [x] resolver switches when S3 file is changed
```bash
$ echo "---
# primary cluster
primary: 0

# secondary cluster
secondary: 100\n" > s3-toggle-resolver.yaml
$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml
```
*Log*:
```
I, [2020-03-12T12:40:05.895056 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update
I, [2020-03-12T12:40:15.954471 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-12T12:40:15.954522 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: chose watcher secondary
```
- [x] resolver does not switch when S3 file is invalid or broken
```bash
$ echo "{" > s3-toggle-resolver.yaml
$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml

# after invalid file is picked up, revert to normal file
$ echo "---# primary cluster
primary: 0

# secondary cluster
secondary: 100\n" > s3-toggle-resolver.yaml
$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml
```

*Log*:
```
W, [2020-03-12T12:41:46.477832 #83639]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: failed to parse s3 file: (<unknown>): did not find expected node content while parsing a flow node at line 2 column 1
W, [2020-03-12T12:41:46.477925 #83639]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: s3 file has invalid schema
W, [2020-03-12T12:41:46.477998 #83639]  WARN -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: received nil watcher weights, not picking

# when uploading new file
I, [2020-03-12T12:42:46.796529 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-12T12:42:46.796575 #83639]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update
```

### Setup
1. Diff applied to `config/discovery-multi-conf.json`:
```diff
diff --git a/config/discovery-multi.conf.json b/config/discovery-multi.conf.json
index fc1bcae..c503fc4 100644
--- a/config/discovery-multi.conf.json
+++ b/config/discovery-multi.conf.json
@@ -13,17 +13,18 @@
       },
       "discovery_multi": {
 	"resolver": {
-	  "method": "fallback"
+	  "method": "s3_toggle",
+	  "s3_url": "s3://synapse-test/s3-toggle-resolver.yaml",
+	  "s3_polling_interval_seconds": 10
 	},
 	"watchers": {
 	  "secondary": {
 	    "method": "zookeeper",
-	    "path": "/services/service1",
+	    "path": "/services/service1-alternative",
 	    "discovery_jitter": 5,
 	    "hosts": [
 	      "localhost:2184",
-	      "localhost:2185",
-	      "localhost:2186"
+	      "localhost:2185"
 	    ]
 	  }
 	}
@@ -46,8 +47,8 @@
     "check_command": "haproxy -c -f /etc/haproxy/haproxy-candidate.cfg",
     "do_reloads": false,
     "reload_command": "sudo service haproxy reload",
-    "do_writes": false,
-    "config_file_path": "/etc/haproxy/haproxy.cfg",
+    "do_writes": true,
+    "config_file_path": "haproxy.cfg",
     "do_socket": false,
     "socket_file_path": "/var/haproxy/stats.sock",
     "global": [

```

2. Run [Minio](https://github.com/minio/minio) locally as S3-compatible store:
```bash
$ mkdir -p "$HOME/docker/volumes/minio/data"
$ docker run --rm -p 9000:9000 --volume="$HOME/docker/volumes/minio/data:/data" minio/minio server /data
```
3. Create test file `s3-toggle-resolver.yaml` with contents:
```yaml
---
# primary cluster
primary: 100

# secondary cluster
secondary: 0
```
4. Create bucket and copy test file:
```bash
$ export AWS_ACCESS_KEY_ID=minioadmin
$ export AWS_SECRET_ACCESS_KEY=minioadmin
$ aws --endpoint-url http://localhost:9000 s3api create-bucket --bucket synapse-test
$ aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml
```
5. Run Zookeeper locally
6. Run Synapse with
```bash
$  AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin AWS_ENDPOINT_URL=http://localhost:9000 RUBYLIB=lib bin/synapse -c config/discovery-multi.conf.json
```

## Reviewers
@bsherrod @austin-zhu 