### PR TITLE
Allow resolver to send notifications to MultiWatcher

### DIFF
--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -54,7 +54,8 @@ class Synapse::ServiceWatcher
       end
 
       @resolver = Synapse::ServiceWatcher::Resolver.load_resolver(@discovery['resolver'],
-                                                                  @watchers)
+                                                                  @watchers,
+                                                                  -> { resolver_notification })
     end
 
     def start
@@ -109,6 +110,10 @@ class Synapse::ServiceWatcher
           raise ArgumentError, "discovery method not included in config for watcher #{watcher_name}"
         end
       end
+    end
+
+    def resolver_notification
+      set_backends(backends)
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/resolver.rb
+++ b/lib/synapse/service_watcher/multi/resolver.rb
@@ -1,6 +1,6 @@
 class Synapse::ServiceWatcher
   class Resolver
-    def self.load_resolver(opts, watchers)
+    def self.load_resolver(opts, watchers, notification_callback)
       raise ArgumentError, "resolver method not provided" unless opts.has_key?('method')
       method = opts['method'].downcase
 
@@ -12,7 +12,7 @@ class Synapse::ServiceWatcher
                    raise ArgumentError, "specified a resolver method of #{method}, which could not be found: #{e}"
                  end
 
-      return resolver.new(opts, watchers)
+      return resolver.new(opts, watchers, notification_callback)
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -19,6 +19,7 @@ class Synapse::ServiceWatcher::MultiWatcher::Resolver
 
       def start
 	     # start resolver
+		 # if you need to trigger a reconfigure, call send_notification
 	  end
 
 	  def stop
@@ -39,7 +40,7 @@ end
 ### Resolver Plugin Interface
 Synapse deduces both the class path and class name from the `method` key within
 the resolver configuration.  Every resolver is passed configuration with the
-`method` key, e.g. `zookeeper` or `ec2tag`.
+`method` key, e.g. `base` or `s3_toggle`.
 
 #### Class Location
 Synapse expects to find your class at `synapse/service_watcher/multi/#{method}`.
@@ -56,5 +57,5 @@ method_class  = method.split('_').map{|x| x.capitalize}.join.concat('Resolver')
 
 This has the effect of taking the method, splitting on '_', capitalizing each
 part and recombining with an added 'Resolver' on the end. So `fallback`
-becomes `FallbackResolver`, and `union` becomes `UnionResolver`. Make sure
-your class name is correct.
+becomes `FallbackResolver`, and `s3_toggle` becomes `S3ToggleResolver`. Make
+sure your class name is correct.

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -6,13 +6,14 @@ class Synapse::ServiceWatcher::Resolver
     include Synapse::Logging
     include Synapse::StatsD
 
-    def initialize(opts, watchers)
+    def initialize(opts, watchers, notification_callback)
       super()
 
       log.info "creating base resolver"
 
       @opts = opts
       @watchers = watchers
+      @notification_callback = notification_callback
       validate_opts
     end
 
@@ -39,6 +40,10 @@ class Synapse::ServiceWatcher::Resolver
     # should be overridden in child classes
     def healthy?
       return true
+    end
+
+    def send_notification
+      @notification_callback.call
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -29,8 +29,8 @@ class Synapse::ServiceWatcher::Resolver
 
     @@s3_client = AWS::S3::Client.new
 
-    def initialize(opts, watchers)
-      super(opts, watchers)
+    def initialize(opts, watchers, notification_callback)
+      super(opts, watchers, notification_callback)
 
       @watcher_mu = Mutex.new
       @watcher_setting = DEFAULT_WATCHER
@@ -123,6 +123,7 @@ class Synapse::ServiceWatcher::Resolver
         @watcher_setting = picked_watcher
       }
 
+      send_notification
       return picked_watcher
     end
 

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -13,8 +13,10 @@ describe Synapse::ServiceWatcher::Resolver::BaseResolver do
     ]
   }
 
+  let(:notification_callback) { -> {} }
+
   subject {
-    Synapse::ServiceWatcher::Resolver::BaseResolver.new(opts, watchers)
+    Synapse::ServiceWatcher::Resolver::BaseResolver.new(opts, watchers, notification_callback)
   }
 
   describe "#initialize" do
@@ -64,6 +66,13 @@ describe Synapse::ServiceWatcher::Resolver::BaseResolver do
   describe "#healthy?" do
     it 'returns true by default' do
       expect(subject.healthy?).to eq(true)
+    end
+  end
+
+  describe 'send_notification' do
+    it 'calls the provided callback' do
+      expect(notification_callback).to receive(:call).exactly(:once)
+      subject.send(:send_notification)
     end
   end
 end

--- a/spec/lib/synapse/multi_resolver/loader_spec.rb
+++ b/spec/lib/synapse/multi_resolver/loader_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'synapse/service_watcher/base/base'
 require 'synapse/service_watcher/multi/resolver'
 require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/service_watcher/multi/resolver/s3_toggle'
 
 describe Synapse::ServiceWatcher::Resolver do
   subject { Synapse::ServiceWatcher::Resolver }
@@ -12,6 +13,8 @@ describe Synapse::ServiceWatcher::Resolver do
     ]
   }
 
+  let (:callback) { -> {} }
+
   describe ".load_resolver" do
     let(:config) { {'method' => 'base'} }
     subject {
@@ -20,8 +23,17 @@ describe Synapse::ServiceWatcher::Resolver do
 
     context 'with method => base' do
       it 'creates the base resolver' do
-        expect(subject::BaseResolver).to receive(:new).exactly(:once).with(config, watchers)
-        expect { subject.load_resolver(config, watchers) }.not_to raise_error
+        expect(subject::BaseResolver).to receive(:new).exactly(:once).with(config, watchers, callback)
+        expect { subject.load_resolver(config, watchers, callback) }.not_to raise_error
+      end
+    end
+
+    context 'with method => s3_toggle' do
+      let(:config) { {'method' => 's3_toggle'} }
+
+      it 'creates the s3 toggle resolver' do
+        expect(subject::S3ToggleResolver).to receive(:new).exactly(:once).with(config, watchers, callback)
+        expect { subject.load_resolver(config, watchers, callback) }.not_to raise_error
       end
     end
 
@@ -30,7 +42,7 @@ describe Synapse::ServiceWatcher::Resolver do
 
       it 'raises an error' do
         expect(subject::BaseResolver).not_to receive(:new)
-        expect { subject.load_resolver(config, watchers) }.to raise_error(ArgumentError)
+        expect { subject.load_resolver(config, watchers, callback) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -292,4 +292,20 @@ describe Synapse::ServiceWatcher::MultiWatcher do
       end
     end
   end
+
+  describe "resolver" do
+    context 'when resolver sends a notification' do
+      let(:mock_backends) { ['host_1', 'host_2'] }
+
+      it 'sets backends to resolver backends' do
+        expect(subject).to receive(:resolver_notification).exactly(:once).and_call_original
+        expect(subject).to receive(:set_backends).exactly(:once).with(mock_backends)
+
+        resolver = subject.instance_variable_get(:@resolver)
+        allow(resolver).to receive(:merged_backends).exactly(:once).and_return(mock_backends)
+
+        resolver.send(:send_notification)
+      end
+    end
+  end
 end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -188,7 +188,8 @@ describe Synapse::ServiceWatcher::MultiWatcher do
           .to receive(:new)
           .with({'method' => 'base'},
                 {'primary' => instance_of(Synapse::ServiceWatcher::ZookeeperWatcher),
-                  'secondary' => instance_of(Synapse::ServiceWatcher::DnsWatcher)})
+                 'secondary' => instance_of(Synapse::ServiceWatcher::DnsWatcher)},
+                duck_type(:call))
           .and_call_original
 
         expect { subject.new(config, mock_synapse, reconfigure_callback) }.not_to raise_error


### PR DESCRIPTION
## Summary
A `resolver` can independently trigger a change of the backends. For example, the new `S3ToggleResolver` can result in a new set of backends if the S3 file changes. That is, say we have two watchers with the following backends:

* A --> `[host_1, host_2]`
* B --> `[host_3, host_4]`

Say in S3, the toggle file originally says to only take backends from `A`. Then, that file changes to only take backends from `B`. `S3ToggleResolver` will notice this change, and change its reported backends to `[host_3, host_4]`.

Before this PR, those changes were not reflected because the underlying watchers themselves had not changed their backends. That is, neither watcher `A` nor watcher `B`'s backends changed. Instead, what changed is *how* we resolve the backends between the two. 

In order for that change to be reflected in Synapse (and the generated configuration for HAProxy), the resolver needs to be able to tell the main loop that something has changed.

## Todo
- [x] new unit tests
- [x] manual testing

## Tests
- [x] unit tests
- [x] changing S3 file reflects in `haproxy.cfg` file change
In this test, the `primary` watcher reads a ZK path that has one instance: `i-primary`.
The `secondary` watcher reads a ZK path that has two instances: `i-secondary` and `i-secondary2`.

1. Haproxy config before changing S3 file (reading primary):
```bash
$ grep "server i-" haproxy.cfg
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 1 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
```
2. Change S3 file to read entirely from secondary:
```bash
$ echo "---
# primary cluster
primary: 0

# secondary cluster
secondary: 100\n" > s3-toggle-resolver.yaml

$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml
```
3. Synapse reads the new file and reconfigures HAProxy:
```
I, [2020-03-12T15:21:19.930178 #98585]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-12T15:21:19.930239 #98585]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver: synapse: s3 toggle resolver: chose watcher secondary
I, [2020-03-12T15:21:19.930436 #98585]  INFO -- Synapse::ServiceWatcher::MultiWatcher: synapse: discovered 2 backends for service service1
I, [2020-03-12T15:21:19.930464 #98585]  INFO -- Synapse::ServiceWatcher::MultiWatcher: synapse: no config_for_generator data from service1 for service service1; keep existing config_for_generator
I, [2020-03-12T15:21:20.770567 #98585]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-03-12T15:21:20.771367 #98585]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because config_for_generator changed. before: {}, after: {"server_options"=>"check inter 2s rise 3 fall 2", "server_port_override"=>nil, "backend"=>[], "frontend"=>[], "listen"=>["mode http", "option httpchk /health", "http-check expect string OK"], "port"=>3213, "bind_options"=>"ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305"}
```
4. HAProxy reflects new backends:
```bash
$ grep "server i-" haproxy.cfg
        server i-secondary_127.0.0.2:2000 127.0.0.2:2000 id 3 cookie i-secondary_127.0.0.2:2000 check inter 2s rise 3 fall 2
        server i-secondary2_127.0.0.3:2001 127.0.0.3:2001 id 2 cookie i-secondary2_127.0.0.3:2001 check inter 2s rise 3 fall 2
```

## Reviewers
@austin-zhu @bsherrod 