### PR TITLE
De-duplicate S3 file reads

### DIFF
--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -202,6 +202,8 @@ class Synapse::ServiceWatcher::Resolver
 
       # pick and set a new watcher, but only if the hash has changed
       def set_watcher(path_data, watcher_weights)
+        path_data[:last_run] = Time.now
+
         if watcher_weights.hash == path_data[:last_content_hash]
           log.info "synapse: s3 toggle resolver: watcher weights hash does not change; ignoring update"
           statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:skip'])
@@ -216,7 +218,6 @@ class Synapse::ServiceWatcher::Resolver
 
         path_data[:picked_watcher] = picked_watcher
         path_data[:last_content_hash] = watcher_weights.hash
-        path_data[:last_run] = Time.now
 
         path_data[:callbacks].each do |cb|
           cb.call(picked_watcher)

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -168,11 +168,13 @@ class Synapse::ServiceWatcher::Resolver
           log.info "synapse: s3 toggle resolver: background thread starting"
 
           while true
+            should_exit = nil
             @mu.synchronize {
-              return if @should_exit
+              should_exit = @should_exit
               update_s3_picks
             }
 
+            break if should_exit
             sleep 1
           end
 

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -229,7 +229,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
     let(:interval) { 60 }
     let(:last_run) { Time.now - interval - 1 }
-    let(:mock_callback) { -> (path){} }
+    let(:mock_callback) { ->(path) {} }
     let(:path_data) {
       {:bucket => 'bucket', :key => 'key', :polling_interval => interval,
        :last_run => last_run, :picked_watcher => nil, :last_content_hash => nil,

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -280,13 +280,6 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
     end
 
     describe '#start' do
-      it 'increments a counter' do
-        allow(Thread).to receive(:new)
-        expect { subject.start }
-          .to change { subject.instance_variable_get(:@callback_count) }
-          .by(1)
-      end
-
       it 'starts a thread' do
         expect(Thread).to receive(:new).exactly(:once)
         subject.start
@@ -312,37 +305,18 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
         subject.instance_variable_set(:@thread, thread)
       end
 
-      it 'increments a counter' do
-        allow(thread).to receive(:join)
-        expect { subject.stop }
-          .to change { subject.instance_variable_get(:@stop_count) }
-          .by(1)
-      end
+      it 'stops the thread' do
+        expect(thread).to receive(:join).exactly(:once)
+        subject.instance_variable_set(:@callback_count, 5)
 
-      context 'when all started paths are stopped' do
-        it 'stops the thread' do
-          expect(thread).to receive(:join).exactly(:once)
-          subject.instance_variable_set(:@callback_count, 5)
-
-          (1..5).each do
-            subject.stop
-          end
-        end
-      end
-
-      context 'when only some started paths are stopped' do
-        it 'does not stop the thread' do
-          expect(thread).not_to receive(:join)
-          subject.instance_variable_set(:@callback_count, 5)
-
-          (1..3).each do
-            subject.stop
-          end
+        (1..5).each do
+          subject.stop
         end
       end
 
       context 'when thread does not exist' do
         let(:thread) { nil }
+
         it 'continues silently' do
           expect { subject.stop }.not_to raise_error
         end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -31,10 +31,13 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
   subject { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts, watchers, -> {}) }
 
   describe '#initialize' do
-    context 'with valid arguments' do
-      it 'constructs normally' do
-        expect { subject }.not_to raise_error
-      end
+    it 'constructs normally' do
+      expect { subject }.not_to raise_error
+    end
+
+    it 'creates an S3BackgroundPoller' do
+      expect(Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller).to receive(:new).exactly(:once)
+      subject
     end
 
     context 'with invalid arguments' do
@@ -85,101 +88,32 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
   end
 
   describe '#start' do
-    it 'starts a thread' do
-      expect(Thread).to receive(:new).exactly(:once)
-      subject.start
+    let(:background_poller) { double("BackgroundS3Poller") }
+
+    before :each do
+      Synapse::ServiceWatcher::Resolver::S3ToggleResolver.class_variable_set(:@@s3_watcher, background_poller)
     end
 
-    context 'with multiple resolvers' do
-      let(:opts1) { opts }
-      let(:opts2) { opts }
-      let(:r1) { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts1, watchers, -> {}) }
-      let(:r2) { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts2, watchers, -> {}) }
+    it 'adds s3 file to the background poller' do
+      expect(background_poller)
+        .to receive(:add_path)
+        .exactly(:once)
+        .with('config_bucket', 'path1/path2', 60, duck_type(:call))
 
-      context 'with different configuration' do
-        let(:opts1) { opts.merge({'s3_url' => 's3://new/path'}) }
-
-        it 'starts two threads' do
-          expect(Thread).to receive(:new).exactly(:twice)
-          r1.start
-          r2.start
-        end
-      end
-
-      context 'with same configuration' do
-        it 'only starts one thread' do
-          expect(Thread).to receive(:new).exactly(:once)
-          r1.start
-          r2.start
-        end
-      end
+      subject.start
     end
   end
 
   describe '#stop' do
-    context 'with a thread running' do
-      let(:mock_thread) { double(Thread) }
+    let(:background_poller) { double("BackgroundS3Poller") }
 
-      it 'waits to exit' do
-        subject.instance_variable_set(:@thread, mock_thread)
-        expect(mock_thread).to receive(:join).exactly(:once)
-        subject.stop
-      end
+    before :each do
+      Synapse::ServiceWatcher::Resolver::S3ToggleResolver.class_variable_set(:@@s3_watcher, background_poller)
     end
 
-    context 'without a thread running' do
-      it 'continues silently' do
-        subject.stop
-      end
-    end
-
-    context 'with multiple resolvers' do
-      let(:opts1) { opts }
-      let(:opts2) { opts }
-      let(:r1) { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts1, watchers, -> {}) }
-      let(:r2) { Synapse::ServiceWatcher::Resolver::S3ToggleResolver.new(opts2, watchers, -> {}) }
-
-      context 'with different configuration' do
-        let(:opts1) { opts.merge({'s3_url' => 's3://new/path'}) }
-        let(:thread1) { double(Thread) }
-        let(:thread2) { double(Thread) }
-
-        before :each do
-          r1.instance_variable_set(:@thread, thread1)
-          r2.instance_variable_set(:@thread, thread2)
-        end
-
-        it 'calls join on each' do
-          expect(thread1).to receive(:join).exactly(:once)
-          expect(thread2).to receive(:join).exactly(:once)
-          r1.stop
-          r2.stop
-        end
-      end
-
-      context 'with same configuration' do
-        let(:thread) { double(Thread) }
-
-        before :each do
-          r1.instance_variable_set(:@thread, thread)
-          r2.instance_variable_set(:@thread, thread)
-        end
-
-        context 'when stopping just one' do
-          it 'does not stop the thread' do
-            expect(thread).not_to receive(:join)
-            r1.stop
-          end
-        end
-
-        context 'when stopping both' do
-          it 'stops the thread' do
-            expect(thread).to receive(:join).exactly(:once)
-            r1.stop
-            r2.stop
-          end
-        end
-      end
+    it 'calls stop on background poller' do
+      expect(background_poller).to receive(:stop).exactly(:once)
+      subject.stop
     end
   end
 
@@ -250,62 +184,100 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
     end
   end
 
-  describe 'pick_watcher' do
-    let(:watcher_weights) { {'primary' => 0, 'secondary' => 100} }
-
-    it 'picks between the watchers by weight' do
-      distribution = {'primary' => 25, 'secondary' => 75}
-      results = {}
-      distribution.each_key do |k|
-        results[k] = 0
-      end
-
-      (0..100).each do
-        choice = subject.send(:pick_watcher, distribution)
-        results[choice] += 1
-      end
-
-      # check distribution of results instead of actual choices
-      expect(results['primary']).to be > 0
-      expect(results['secondary']).to be > 0
-      expect(results['secondary']).to be > results['primary']
+  describe 'set_backends' do
+    context 'with unknown watchers' do
+      it 'ignores updates'
     end
+  end
 
-    context 'when primary has all weight' do
-      let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
+  describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller do
+    subject { Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller.new }
 
-      it 'returns primary' do
-        expect(subject.send(:pick_watcher, watcher_weights)).to eq('primary')
+    let(:interval) { 60 }
+    let(:last_run) { Time.now - interval - 1 }
+    let(:mock_callback) { -> (path){} }
+    let(:path_data) {
+      {:bucket => 'bucket', :key => 'key', :polling_interval => interval,
+       :last_run => last_run, :picked_watcher => nil, :last_content_hash => nil,
+       :callbacks => [ mock_callback ]}
+    }
+
+    describe '#add_path' do
+      it 'calls start'
+
+      context 'with a new path' do
+        it 'adds it to @paths'
+        it 'adds the new callback'
       end
-    end
 
-    context 'when weights are empty' do
-      let(:watcher_weights) { {} }
+      context 'with an existing path' do
+        context 'with same interval' do
+          it 'does not add it to @paths'
+          it 'does not add a new callback'
+        end
 
-      it 'returns nil' do
-        expect(subject.send(:pick_watcher, watcher_weights)).to eq(nil)
-      end
-    end
-
-    context 'when weights are nil' do
-      let(:watcher_weights) { nil }
-
-      it 'returns nil' do
-        expect(subject.send(:pick_watcher, watcher_weights).nil?).to eq(true)
+        context 'with new interval' do
+          it 'adds it to @paths'
+          it 'adds the new callback'
+        end
       end
     end
 
-    context 'when weights add up to more than 100' do
-      let(:watcher_weights) { {'primary' => 50, 'secondary' => 100} }
+    describe '#start' do
+      it 'increments a counter'
+      it 'starts a thread'
 
-      it 'still sets watcher properly' do
+      context 'when a thread already exists' do
+        it 'continues silently'
+      end
+    end
+
+    describe '#stop' do
+      it 'increments a counter'
+
+      context 'when all started paths are stopped' do
+        it 'stops the thread'
+      end
+
+      context 'when only some started paths are stopped' do
+        it 'does not stop the thread'
+      end
+
+      context 'when thread does not exist' do
+        it 'continues silently'
+      end
+    end
+
+    describe 'update_s3_picks' do
+      context 'when path is out of date' do
+        it 'reads from s3'
+        it 'calls set_watcher'
+        it 'sets path data properly'
+      end
+
+      context 'when path is up to date' do
+        it 'does not read from s3'
+        it 'does not call set_watcher'
+        it 'does not change path data'
+      end
+
+      context 'with no paths' do
+        it 'continues silently'
+      end
+    end
+
+    describe 'pick_watcher' do
+      let(:watcher_weights) { {'primary' => 0, 'secondary' => 100} }
+
+      it 'picks between the watchers by weight' do
+        distribution = {'primary' => 25, 'secondary' => 75}
         results = {}
-        watcher_weights.each_key do |k|
+        distribution.each_key do |k|
           results[k] = 0
         end
 
         (0..100).each do
-          choice = subject.send(:pick_watcher, watcher_weights)
+          choice = subject.send(:pick_watcher, distribution)
           results[choice] += 1
         end
 
@@ -314,242 +286,282 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
         expect(results['secondary']).to be > 0
         expect(results['secondary']).to be > results['primary']
       end
-    end
 
-    context 'when weights are the same' do
-      let(:watcher_weights) { {'primary' => 50, 'secondary' => 50} }
+      context 'when primary has all weight' do
+        let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
 
-      it 'picks each watcher equally' do
-        distribution = {'primary' => 50, 'secondary' => 50}
-        results = {}
-        distribution.each_key do |k|
-          results[k] = 0
-        end
-
-        (0..1000).each do
-          choice = subject.send(:pick_watcher, distribution)
-          results[choice] += 1
-        end
-
-        # check distribution of results instead of actual choices
-        expect(results['primary']).to be > 0
-        expect(results['secondary']).to be > 0
-        expect(results['secondary']).to be_within(100).of(results['primary'])
-      end
-    end
-
-    context 'when weights add up to 0' do
-      let(:watcher_weights) { {'primary' => 0, 'secondary' => 0} }
-
-      it 'returns nil' do
-        expect(subject.send(:pick_watcher, watcher_weights).nil?).to eq(true)
-      end
-    end
-
-    context 'with unknown watcher' do
-      let(:watcher_weights) { {'primary' => 0, 'secondary' => 1, 'bogus' => 100000} }
-
-      it 'ignores unknown watchers' do
-        (0..100).each do
-          expect(subject.send(:pick_watcher, watcher_weights)).to eq('secondary')
+        it 'returns primary' do
+          expect(subject.send(:pick_watcher, watcher_weights)).to eq('primary')
         end
       end
-    end
 
-    context 'with only unknown watchers' do
-      let(:watcher_weights) { {'bogus' => 10000} }
+      context 'when weights are empty' do
+        let(:watcher_weights) { {} }
 
-      it 'does not pick' do
-        (0..100).each do
+        it 'returns nil' do
           expect(subject.send(:pick_watcher, watcher_weights)).to eq(nil)
         end
       end
-    end
-  end
 
-  describe 'set_watcher' do
-    let(:watcher_weights) { {'primary' => 50, 'secondary' => 50} }
+      context 'when weights are nil' do
+        let(:watcher_weights) { nil }
 
-    it 'sets @watcher_setting' do
-      subject.send(:set_watcher, {'primary' => 0, 'secondary' => 100})
-      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
-    end
-
-    it 'calls set_watcher' do
-      expect(subject).to receive(:pick_watcher).with(watcher_weights).exactly(:once)
-      subject.send(:set_watcher, watcher_weights)
-    end
-
-    it 'sends a notification' do
-      expect(subject).to receive(:send_notification).exactly(:once)
-      subject.send(:set_watcher, watcher_weights)
-    end
-
-    context 'when called multiple times' do
-      it 'deterministically picks the same watcher' do
-        expect(subject).to receive(:pick_watcher).with(watcher_weights).exactly(:once).and_call_original
-
-        subject.send(:set_watcher, watcher_weights)
-
-        # Explicitly set the setting to something that cannot occur.
-        # However, it should not change because the weights do not change.
-        subject.instance_variable_set(:@watcher_setting, 'mock-watcher')
-        expect(subject.send(:set_watcher, watcher_weights)).to eq('mock-watcher')
+        it 'returns nil' do
+          expect(subject.send(:pick_watcher, watcher_weights).nil?).to eq(true)
+        end
       end
 
-      it 'only sends one notification' do
-        expect(subject).to receive(:send_notification).exactly(:once)
+      context 'when weights add up to more than 100' do
+        let(:watcher_weights) { {'primary' => 50, 'secondary' => 100} }
 
-        subject.send(:set_watcher, watcher_weights)
-        subject.send(:set_watcher, watcher_weights)
+        it 'still sets watcher properly' do
+          results = {}
+          watcher_weights.each_key do |k|
+            results[k] = 0
+          end
+
+          (0..100).each do
+            choice = subject.send(:pick_watcher, watcher_weights)
+            results[choice] += 1
+          end
+
+          # check distribution of results instead of actual choices
+          expect(results['primary']).to be > 0
+          expect(results['secondary']).to be > 0
+          expect(results['secondary']).to be > results['primary']
+        end
+      end
+
+      context 'when weights are the same' do
+        let(:watcher_weights) { {'primary' => 50, 'secondary' => 50} }
+
+        it 'picks each watcher equally' do
+          distribution = {'primary' => 50, 'secondary' => 50}
+          results = {}
+          distribution.each_key do |k|
+            results[k] = 0
+          end
+
+          (0..1000).each do
+            choice = subject.send(:pick_watcher, distribution)
+            results[choice] += 1
+          end
+
+          # check distribution of results instead of actual choices
+          expect(results['primary']).to be > 0
+          expect(results['secondary']).to be > 0
+          expect(results['secondary']).to be_within(100).of(results['primary'])
+        end
+      end
+
+      context 'when weights add up to 0' do
+        let(:watcher_weights) { {'primary' => 0, 'secondary' => 0} }
+
+        it 'returns nil' do
+          expect(subject.send(:pick_watcher, watcher_weights).nil?).to eq(true)
+        end
       end
     end
 
-    context 'with different weights' do
-      let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
-      let(:watcher_weights_new) { {'primary' => 0, 'secondary' => 100} }
+    describe 'set_watcher' do
+      let(:watcher_weights) { {'primary' => 0, 'secondary' => 100} }
 
-      it 'picks a new watcher' do
-        expect(subject).to receive(:pick_watcher).with(watcher_weights).exactly(:once).and_call_original
-        expect(subject).to receive(:pick_watcher).with(watcher_weights_new).exactly(:once).and_call_original
+      it 'sets :picked_watcher' do
+        subject.send(:set_watcher,  path_data, watcher_weights)
+        expect(path_data[:picked_watcher]).to eq('secondary')
+      end
 
-        expect(subject.send(:set_watcher, watcher_weights)).to eq('primary')
-        expect(subject.send(:set_watcher, watcher_weights_new)).to eq('secondary')
+      it 'calls pick_watcher' do
+        expect(subject).to receive(:pick_watcher).with(watcher_weights).exactly(:once)
+        subject.send(:set_watcher, path_data, watcher_weights)
       end
 
       it 'sends a notification' do
-        expect(subject).to receive(:send_notification).exactly(:twice)
+        expect(mock_callback).to receive(:call).exactly(:once).with('secondary')
+        subject.send(:set_watcher, path_data, watcher_weights)
+      end
 
-        subject.send(:set_watcher, watcher_weights)
-        subject.send(:set_watcher, watcher_weights_new)
+      context 'with multiple callbacks' do
+        it 'calls each one'
+      end
+
+      context 'when called multiple times' do
+        it 'deterministically picks the same watcher' do
+          expect(subject)
+            .to receive(:pick_watcher)
+            .with(watcher_weights)
+            .exactly(:once)
+            .and_call_original
+
+          subject.send(:set_watcher, path_data, watcher_weights)
+
+          # Explicitly set the setting to something that cannot occur.
+          # However, it should not change because the weights do not change.
+          path_data[:picked_watcher] = 'mock-watcher'
+          expect(subject.send(:set_watcher, path_data, watcher_weights)).to eq('mock-watcher')
+        end
+
+        it 'only sends one notification' do
+          expect(mock_callback).to receive(:call).exactly(:once)
+
+          subject.send(:set_watcher, path_data, watcher_weights)
+          subject.send(:set_watcher, path_data, watcher_weights)
+        end
+      end
+
+      context 'with different weights' do
+        let(:watcher_weights) { {'primary' => 100, 'secondary' => 0} }
+        let(:watcher_weights_new) { {'primary' => 0, 'secondary' => 100} }
+
+        it 'picks a new watcher' do
+          expect(subject)
+            .to receive(:pick_watcher)
+            .with(watcher_weights)
+            .exactly(:once)
+            .and_call_original
+
+          expect(subject)
+            .to receive(:pick_watcher)
+            .with(watcher_weights_new)
+            .exactly(:once)
+            .and_call_original
+
+          expect(subject.send(:set_watcher, path_data, watcher_weights)).to eq('primary')
+          expect(subject.send(:set_watcher, path_data, watcher_weights_new)).to eq('secondary')
+        end
+
+        it 'sends a notification' do
+          expect(mock_callback).to receive(:call).exactly(:twice)
+
+          subject.send(:set_watcher, path_data, watcher_weights)
+          subject.send(:set_watcher, path_data, watcher_weights_new)
+        end
+      end
+
+      context 'when pick_watcher returns nil' do
+        before :each do
+          allow(subject).to receive(:pick_watcher).and_return(nil)
+          path_data[:picked_watcher] = 'mock-watcher'
+        end
+
+        it 'does not change the watcher' do
+          expect(subject.send(:set_watcher, path_data, watcher_weights)).to eq('mock-watcher')
+          expect(path_data[:picked_watcher]).to eq('mock-watcher')
+        end
+
+        it 'does not send a notification' do
+          expect(mock_callback).not_to receive(:call)
+          subject.send(:set_watcher, path_data, watcher_weights)
+        end
       end
     end
 
-    context 'when pick_watcher returns nil' do
-      before :each do
-        allow(subject).to receive(:pick_watcher).and_return(nil)
-        subject.instance_variable_set(:@watcher_setting, 'mock-watcher')
-      end
+    describe 'read_s3_file' do
+      let(:s3_data) { {'primary' => 50, 'secondary' => 50} }
+      let(:s3_data_string) { YAML.dump(s3_data) }
+      let(:s3_bucket) { 'config_bucket' }
+      let(:s3_path) { 'path1/path2' }
+      let(:mock_s3_response) {
+        mock_response = double("mock_s3_response")
+        allow(mock_response).to receive(:data).and_return({:data => s3_data_string})
+        mock_response
+      }
 
-      it 'does not change the watcher' do
-        expect(subject.send(:set_watcher, watcher_weights)).to eq('mock-watcher')
-      end
-
-      it 'does not send a notification' do
-        expect(subject).not_to receive(:send_notification)
-        subject.send(:set_watcher, watcher_weights)
-      end
-    end
-  end
-
-  describe 'read_s3_file' do
-    let(:s3_data) { {'primary' => 50, 'secondary' => 50} }
-    let(:s3_data_string) { YAML.dump(s3_data) }
-    let(:mock_s3_response) {
-      mock_response = double("mock_s3_response")
-      allow(mock_response).to receive(:data).and_return({:data => s3_data_string})
-      mock_response
-    }
-
-    let(:mock_s3) {
-      mock_s3 = double(AWS::S3::Client)
-      Synapse::ServiceWatcher::Resolver::S3ToggleResolver.class_variable_set(:@@s3_client, mock_s3)
-      mock_s3
-    }
-
-    before :each do
-      subject.instance_variable_set(:@s3_bucket, 'config_bucket')
-      subject.instance_variable_set(:@s3_path, 'path1/path2')
-    end
-
-    it 'properly parses response' do
-      allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
-      expect(subject.send(:read_s3_file)).to eq(s3_data)
-    end
-
-    context 'with yaml comments' do
-      let(:s3_data_string) { "---\n# example comment\nprimary: 50\nsecondary: 50" }
+      let(:mock_s3) {
+        mock_s3 = double(AWS::S3::Client)
+        Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller.class_variable_set(:@@s3_client, mock_s3)
+        mock_s3
+      }
 
       it 'properly parses response' do
         allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
-        expect(subject.send(:read_s3_file)).to eq(s3_data)
+        expect(subject.send(:read_s3_file, s3_bucket, s3_path)).to eq(s3_data)
+      end
+
+      context 'with yaml comments' do
+        let(:s3_data_string) { "---\n# example comment\nprimary: 50\nsecondary: 50" }
+
+        it 'properly parses response' do
+          allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
+          expect(subject.send(:read_s3_file, s3_bucket, s3_path)).to eq(s3_data)
+        end
+      end
+
+      it 'calls S3 API with proper bucket and key' do
+        expect(mock_s3)
+          .to receive(:get_object)
+          .with(bucket_name: s3_bucket, key: s3_path)
+          .exactly(:once)
+          .and_return(mock_s3_response)
+
+        subject.send(:read_s3_file, s3_bucket, s3_path)
+      end
+
+      context 'with s3 errors' do
+        it 'returns an empty configuration' do
+          expect(mock_s3).to receive(:get_object).and_raise(AWS::S3::Errors::NoSuchBucket)
+          expect(subject.send(:read_s3_file, s3_bucket, s3_path)).to eq(nil)
+        end
+      end
+
+      context 'with invalid yaml' do
+        let(:s3_data_string) { "{" }
+
+        it 'returns an empty configuration' do
+          allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
+          expect(subject.send(:read_s3_file, s3_bucket, s3_path)).to eq(nil)
+        end
+      end
+
+      context 'with invalid schema' do
+        let(:s3_data) { {"watchers" => [{"bogus" => 10}, {"morebogus" => 11}]} }
+
+        it 'returns an empty configuration' do
+          allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
+          expect(subject.send(:read_s3_file, s3_bucket, s3_path)).to eq(nil)
+        end
       end
     end
 
-    it 'calls S3 API with proper bucket and key' do
-      expect(mock_s3)
-        .to receive(:get_object)
-        .with(bucket_name: 'config_bucket', key: 'path1/path2')
-        .exactly(:once)
-        .and_return(mock_s3_response)
+    describe 'validate_s3_file_schema' do
+      context 'with invalid schema' do
+        let(:schema) { {"watchers" => [{"bogus" => 10}, {"morebogus" => 11}]} }
 
-      subject.send(:read_s3_file)
-    end
-
-    context 'with s3 errors' do
-      it 'returns an empty configuration' do
-        expect(mock_s3).to receive(:get_object).and_raise(AWS::S3::Errors::NoSuchBucket)
-        expect(subject.send(:read_s3_file)).to eq(nil)
+        it 'returns false' do
+          expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
+        end
       end
-    end
 
-    context 'with invalid yaml' do
-      let(:s3_data_string) { "{" }
+      context 'with invalid type' do
+        let(:schema) { "bogus" }
 
-      it 'returns an empty configuration' do
-        allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
-        expect(subject.send(:read_s3_file)).to eq(nil)
+        it 'returns false' do
+          expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
+        end
       end
-    end
 
-    context 'with invalid schema' do
-      let(:s3_data) { {"watchers" => [{"bogus" => 10}, {"morebogus" => 11}]} }
+      context 'with nil contents' do
+        let(:schema) { nil }
 
-      it 'returns an empty configuration' do
-        allow(mock_s3).to receive(:get_object).and_return(mock_s3_response)
-        expect(subject.send(:read_s3_file)).to eq(nil)
+        it 'returns false' do
+          expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
+        end
       end
-    end
-  end
 
-  describe 'validate_s3_file_schema' do
-    context 'with invalid schema' do
-      let(:schema) { {"watchers" => [{"bogus" => 10}, {"morebogus" => 11}]} }
+      context 'with floating-point weights' do
+        let(:schema) { {"primary" => 0.25, "secondary" => 0.75} }
 
-      it 'returns false' do
-        expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
+        it 'returns false' do
+          expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
+        end
       end
-    end
 
-    context 'with invalid type' do
-      let(:schema) { "bogus" }
+      context 'with valid schema' do
+        let(:schema) { {'primary' => 50, 'secondary' => 50} }
 
-      it 'returns false' do
-        expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
-      end
-    end
-
-    context 'with nil contents' do
-      let(:schema) { nil }
-
-      it 'returns false' do
-        expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
-      end
-    end
-
-    context 'with floating-point weights' do
-      let(:schema) { {"primary" => 0.25, "secondary" => 0.75} }
-
-      it 'returns false' do
-        expect(subject.send(:validate_s3_file_schema, schema)).to eq(false)
-      end
-    end
-
-    context 'with valid schema' do
-      let(:schema) { {'primary' => 50, 'secondary' => 50} }
-
-      it 'returns true' do
-        expect(subject.send(:validate_s3_file_schema, schema)).to eq(true)
+        it 'returns true' do
+          expect(subject.send(:validate_s3_file_schema, schema)).to eq(true)
+        end
       end
     end
   end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -563,6 +563,17 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
           subject.send(:set_watcher, path_data, watcher_weights)
           subject.send(:set_watcher, path_data, watcher_weights)
         end
+
+        it 'updates last_run time' do
+          travel_to Time.now
+          subject.send(:set_watcher, path_data, watcher_weights)
+          expect(path_data[:last_run]).to eq(Time.now)
+
+          second_run = Time.now + 1
+          travel_to second_run
+          subject.send(:set_watcher, path_data, watcher_weights)
+          expect(path_data[:last_run]).to eq(second_run)
+        end
       end
 
       context 'with different weights' do


### PR DESCRIPTION
## Summary
Currently, the `S3ToggleResolver` will read the provided S3 file for every multi-watcher created. When a single Synapse has N watchers, the file will be read N times periodically. This creates unnecessary load.

This PR abstracts the S3 file reading into a separate `BackgroundS3Poller` class which performs the function of reading an S3 file, validating it, and deterministically picking a watcher. That watcher is shared by any `MultiWatcher` which uses that file.

Different `MultiWatcher` still have the flexibility of reading different S3 files; the `BackgroundS3Poller` will automatically manage this.

## Testing
- [x] unit tests
- [x] re-run multi-watcher tests (see: #311)
- [x] with multiple dependencies, S3 file is only read once per interval
```bash
$ grep "read s3" test.out
I, [2020-03-25T13:13:14.954019 #19280]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-25T13:13:24.991642 #19280]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-25T13:13:35.027976 #19280]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
```
- [x] with multiple dependencies with different S3 files, each is read once per interval
```bash
$ I, [2020-03-25T13:16:56.025077 #27293]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-25T13:17:02.053431 #27293]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary-NEW"=>0, "secondary-NEW"=>100}
I, [2020-03-25T13:17:06.080453 #27293]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary"=>0, "secondary"=>100}
I, [2020-03-25T13:17:12.107244 #27293]  INFO -- Synapse::ServiceWatcher::Resolver::S3ToggleResolver::BackgroundS3Poller: synapse: s3 toggle resolver: read s3 file: {"primary-NEW"=>0, "secondary-NEW"=>100}
```

## Reviewers
@austin-zhu 