### PR TITLE
Add Union & Sequential resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,26 @@ It is a simple dictionary in YAML where the key refers to the watcher nam
 (as provided to the `MultiWatcher`) and the value is an integer, non-negative
 weight that determines the probability for that watcher to be chosen.
 
+###### Union Resolver ######
+
+The `UnionResolver` merges the backends from each child watcher into a single list.
+For example, with two children watchers that have backends of `[a, b]` and `[c, d]`,
+it will return `[a, b, c, d]`.
+
+* `method`: must be `union`
+
+###### Sequential Resolver ######
+
+The `SequentialResolver` goes through a specific ordering of watchers and returns the
+first set of backends that did not error or return an empty set.
+If `sequential_order` is `['primary', 'secondary']`, it will first read the backends from
+`primary`; `secondary` will only be read if the `primary` fails (by returning an empty set
+of backends).
+
+It takes the following options:
+
+* `method`: must be `sequential`
+* `sequential_order`: a list of watcher names that will be read in the provided order
 
 <a name="defaultservers"/>
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ The `UnionResolver` merges the backends from each child watcher into a single li
 For example, with two children watchers that have backends of `[a, b]` and `[c, d]`,
 it will return `[a, b, c, d]`.
 
+The `config_for_generator` cannot be easily merged; intead, we pick the first non-empty
+config. As such, when using `union` you should ensure that only one watcher returns
+a config or that all watchers have the same config.
+
 * `method`: must be `union`
 
 ###### Sequential Resolver ######
@@ -363,7 +367,7 @@ The `SequentialResolver` goes through a specific ordering of watchers and return
 first set of backends that did not error or return an empty set.
 If `sequential_order` is `['primary', 'secondary']`, it will first read the backends from
 `primary`; `secondary` will only be read if the `primary` fails (by returning an empty set
-of backends).
+of backends). The smae method is used for the `config_for_generator`.
 
 It takes the following options:
 

--- a/lib/synapse/service_watcher/base/base.rb
+++ b/lib/synapse/service_watcher/base/base.rb
@@ -110,6 +110,11 @@ class Synapse::ServiceWatcher
       true
     end
 
+    # this can be overridden in child classes, if different from ping?
+    def watching?
+      ping?
+    end
+
     # deep clone the hash to protect its readonly property
     def config_for_generator
       Marshal.load(Marshal.dump(@config_for_generator.get))

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -84,7 +84,7 @@ class Synapse::ServiceWatcher::Resolver
     def set_watcher(w)
       unless @watchers.keys.include?(w)
         log.warn "synapse: s3 toggle resolver: tried to set unknown watcher #{w}"
-        statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:unknown_watcher'])
+        statsd_increment('synapse.watcher.multi.resolver.s3_toggle.switch', ['result:fail', 'reason:unknown_watcher'])
         return
       end
 

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -1,0 +1,51 @@
+require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/log'
+require 'synapse/statsd'
+
+class Synapse::ServiceWatcher::Resolver
+  class SequentialResolver < BaseResolver
+    include Synapse::Logging
+    include Synapse::StatsD
+
+    def initialize(opts, watchers, reconfigure_callback)
+      @watcher_order = opts['sequential_order']
+      super(opts, watchers, reconfigure_callback)
+    end
+
+    def validate_opts
+      raise ArgumentError, "sequential resolver expects method to be union" unless @opts['method'] == 'sequential'
+      raise ArgumentError, "no watchers provided" unless @watchers.length > 0
+      raise ArgumentError, "no sequential order defined" if @watcher_order.nil?
+
+      watcher_names = @watchers.keys.to_set
+      watcher_order_names = @watcher_order.to_set
+
+      watcher_names.each do |watcher|
+        raise ArgumentError, "sequential_order does not contain: #{watcher}" unless watcher_order_names.include?(watcher)
+      end
+
+      watcher_order_names.each do |watcher|
+        raise ArgumentError, "sequential_order has unknown watcher: #{watcher}" unless watcher_names.include?(watcher)
+      end
+    end
+
+    def merged_backends
+      ordered_watchers.each do |w|
+        backends = w.backends
+        return backends unless backends == []
+      end
+
+      return []
+    end
+
+    def healthy?
+      return ordered_watchers.any? { |w| w.ping? }
+    end
+
+    private
+
+    def ordered_watchers
+      return @watcher_order.map { |w| @watchers[w] }
+    end
+  end
+end

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -21,7 +21,7 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     def validate_opts
-      raise ArgumentError, "sequential resolver expects method to be union" unless @opts['method'] == 'sequential'
+      raise ArgumentError, "sequential resolver expects method to be sequential; currently: #{@opts['method']}" unless @opts['method'] == 'sequential'
       raise ArgumentError, "no watchers provided" unless @watchers.length > 0
       raise ArgumentError, "no sequential order defined" if @watcher_order.nil?
 

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -40,6 +40,17 @@ class Synapse::ServiceWatcher::Resolver
       return []
     end
 
+    def merged_config_for_generator
+      ordered_watchers.each do |w|
+        next unless w.ping?
+
+        config_for_generator = w.config_for_generator
+        return config_for_generator unless config_for_generator == {}
+      end
+
+      return []
+    end
+
     def healthy?
       return ordered_watchers.any? { |w| w.ping? }
     end

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -56,7 +56,7 @@ class Synapse::ServiceWatcher::Resolver
       new_watcher = @watcher_order[0]
 
       ordered_watchers.each do |watcher_name, watcher|
-        if watcher.ping? && watcher.backends != [] && watcher.config_for_generator != {}
+        if watcher.ping? && watcher.watching? && watcher.backends != [] && watcher.config_for_generator != {}
           log.debug "synapse: sequential resolver: first healthy watcher is #{watcher_name}"
           new_watcher = watcher_name
           break

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -1,6 +1,7 @@
 require 'synapse/service_watcher/multi/resolver/base'
 require 'synapse/log'
 require 'synapse/statsd'
+require 'synapse/atomic'
 
 class Synapse::ServiceWatcher::Resolver
   class SequentialResolver < BaseResolver
@@ -10,6 +11,13 @@ class Synapse::ServiceWatcher::Resolver
     def initialize(opts, watchers, reconfigure_callback)
       @watcher_order = opts['sequential_order']
       super(opts, watchers, reconfigure_callback)
+
+      @watcher_setting = Synapse::AtomicValue.new(@watcher_order[0])
+    end
+
+    def start
+      log.info "synapse: sequential resolver: starting"
+      pick_watcher
     end
 
     def validate_opts
@@ -30,35 +38,47 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     def merged_backends
-      ordered_watchers.each do |w|
-        next unless w.ping?
-
-        backends = w.backends
-        return backends unless backends == []
-      end
-
-      return []
+      return current_watcher.backends
     end
 
     def merged_config_for_generator
-      ordered_watchers.each do |w|
-        next unless w.ping?
-
-        config_for_generator = w.config_for_generator
-        return config_for_generator unless config_for_generator == {}
-      end
-
-      return []
+      return current_watcher.config_for_generator
     end
 
     def healthy?
-      return ordered_watchers.any? { |w| w.ping? }
+      pick_watcher
+      return current_watcher.ping?
     end
 
     private
 
+    def pick_watcher
+      new_watcher = @watcher_order[0]
+
+      ordered_watchers.each do |watcher_name, watcher|
+        if watcher.ping? && watcher.backends != [] && watcher.config_for_generator != {}
+          log.debug "synapse: sequential resolver: first healthy watcher is #{watcher_name}"
+          new_watcher = watcher_name
+          break
+        end
+      end
+
+      unless @watcher_setting.get == new_watcher
+        @watcher_setting.set(new_watcher)
+        log.info "synapse: sequential resolver: picked watcher #{new_watcher}"
+        statsd_increment('synapse.watcher.multi.resolver.sequential.switch', ['result:success', "watcher:#{new_watcher}"])
+
+        send_notification
+      end
+    end
+
+    def current_watcher
+      watcher_name = @watcher_setting.get
+      return @watchers[watcher_name]
+    end
+
     def ordered_watchers
-      return @watcher_order.map { |w| @watchers[w] }
+      @watcher_order.map { |w| [w, @watchers[w]] }
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/resolver/sequential.rb
+++ b/lib/synapse/service_watcher/multi/resolver/sequential.rb
@@ -31,6 +31,8 @@ class Synapse::ServiceWatcher::Resolver
 
     def merged_backends
       ordered_watchers.each do |w|
+        next unless w.ping?
+
         backends = w.backends
         return backends unless backends == []
       end

--- a/lib/synapse/service_watcher/multi/resolver/union.rb
+++ b/lib/synapse/service_watcher/multi/resolver/union.rb
@@ -8,7 +8,7 @@ class Synapse::ServiceWatcher::Resolver
     include Synapse::StatsD
 
     def validate_opts
-      raise ArgumentError, "union resolver expects method to be union" unless @opts['method'] == 'union'
+      raise ArgumentError, "union resolver expects method to be union; currently: #{@opts['method']}" unless @opts['method'] == 'union'
       raise ArgumentError, "no watchers provided" unless @watchers.length > 0
     end
 

--- a/lib/synapse/service_watcher/multi/resolver/union.rb
+++ b/lib/synapse/service_watcher/multi/resolver/union.rb
@@ -1,0 +1,23 @@
+require 'synapse/service_watcher/multi/resolver/base'
+require 'synapse/log'
+require 'synapse/statsd'
+
+class Synapse::ServiceWatcher::Resolver
+  class UnionResolver < BaseResolver
+    include Synapse::Logging
+    include Synapse::StatsD
+
+    def validate_opts
+      raise ArgumentError, "union resolver expects method to be union" unless @opts['method'] == 'union'
+      raise ArgumentError, "no watchers provided" unless @watchers.length > 0
+    end
+
+    def merged_backends
+      return @watchers.values.map { |w| w.backends }.flatten
+    end
+
+    def healthy?
+      return @watchers.values.any? { |w| w.ping? }
+    end
+  end
+end

--- a/lib/synapse/service_watcher/multi/resolver/union.rb
+++ b/lib/synapse/service_watcher/multi/resolver/union.rb
@@ -16,6 +16,14 @@ class Synapse::ServiceWatcher::Resolver
       return @watchers.values.map { |w| w.backends }.flatten
     end
 
+    def merged_config_for_generator
+      return @watchers
+        .values
+        .map { |w| w.config_for_generator }
+        .select { |c| !c.empty? }
+        .first || {}
+    end
+
     def healthy?
       return @watchers.values.any? { |w| w.ping? }
     end

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -96,6 +96,13 @@ class Synapse::ServiceWatcher
       @zk && (@zk.associating? || @zk.connecting? || @zk.connected?)
     end
 
+    def watching?
+      # This is different from ping? in that it only returns true if ZK
+      # is connected, which is particularly useful for checking if updates are
+      # being processed (or are stalled).
+      @zk && @zk.connected?
+    end
+
     private
 
     def start_discovery

--- a/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
@@ -23,11 +23,8 @@ class Synapse::ServiceWatcher
         @thread = Thread.new {
           log.info 'synapse: zookeeper polling thread started'
 
-          # last_run is shifted by a random jitter in order to spread the first
-          # discover call of multiple Synapses. This helps to spread load.
-          # As long as the beginning is spread, the future discovers will also
-          # be spread.
-          last_run = Time.now - rand(@poll_interval)
+          # Ensure we poll on first start.
+          last_run = Time.now - @poll_interval - 1
 
           until @should_exit.get
             now = Time.now

--- a/spec/lib/synapse/multi_resolver/loader_spec.rb
+++ b/spec/lib/synapse/multi_resolver/loader_spec.rb
@@ -37,6 +37,24 @@ describe Synapse::ServiceWatcher::Resolver do
       end
     end
 
+    context 'with method => union' do
+      let(:config) { {'method' => 'union'} }
+
+      it 'creates the union resolver' do
+        expect(subject::UnionResolver).to receive(:new).exactly(:once).with(config, watchers, callback)
+        expect { subject.load_resolver(config, watchers, callback) }.not_to raise_error
+      end
+    end
+
+    context 'with method => sequential' do
+      let(:config) { {'method' => 'sequential'} }
+
+      it 'creates the sequential resolver' do
+        expect(subject::SequentialResolver).to receive(:new).exactly(:once).with(config, watchers, callback)
+        expect { subject.load_resolver(config, watchers, callback) }.not_to raise_error
+      end
+    end
+
     context 'with bogus method' do
       let(:config) { {'method' => 'bogus'} }
 

--- a/spec/lib/synapse/multi_resolver/sequential_spec.rb
+++ b/spec/lib/synapse/multi_resolver/sequential_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi/resolver/sequential'
+require 'synapse/service_watcher/base/base'
+
+describe Synapse::ServiceWatcher::Resolver::SequentialResolver do
+  let(:watchers) { {'primary' => primary_watcher, 'secondary' => secondary_watcher} }
+
+  let(:primary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends) { primary_healthy ? primary_backends: [] }
+    allow(w).to receive(:ping?).and_return(primary_healthy)
+    w
+  }
+  let(:primary_backends) { ["primary_1", "primary_2", "primary_3"] }
+  let(:primary_healthy) { true }
+
+  let(:secondary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends) { secondary_healthy ? secondary_backends: [] }
+    allow(w).to receive(:ping?).and_return(secondary_healthy)
+    w
+  }
+  let(:secondary_backends) { ["secondary_1", "secondary_2", "secondary_3"] }
+  let(:secondary_healthy) { true }
+
+  let(:opts) { opts_valid }
+  let(:opts_valid) { {'method' => 'sequential', 'sequential_order' => sequential_order} }
+  let(:sequential_order) { ['primary', 'secondary'] }
+
+  subject { Synapse::ServiceWatcher::Resolver::SequentialResolver.new(opts, watchers, -> {}) }
+
+  describe '#initialize' do
+    it 'constructs normally' do
+      expect { subject }.not_to raise_error
+    end
+
+    context 'without defined sequential_order' do
+      let(:opts) { {'method' => 'sequential'} }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with unknown watchers' do
+      let(:sequential_order) { ['primary', 'bogus', 'secondary'] }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with missing watchers' do
+      let(:sequential_order) { [] }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with invalid method' do
+      let(:opts) { {'method' => 'bogus'} }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#merged_backends' do
+    it 'returns primary backends' do
+      expect(subject.merged_backends).to eq(primary_backends)
+    end
+
+    it 'calls backends only on first watcher' do
+      expect(primary_watcher).to receive(:backends).exactly(:once).and_return(primary_backends)
+      expect(secondary_watcher).not_to receive(:backends)
+      subject.merged_backends
+    end
+
+    context 'when first watcher returns an empty list' do
+      let(:primary_healthy) { false }
+
+      it 'returns secondary backends' do
+        expect(subject.merged_backends).to eq(secondary_backends)
+      end
+
+      it 'calls backends on secondary watcher' do
+        expect(secondary_watcher).to receive(:backends).exactly(:once)
+        subject.merged_backends
+      end
+    end
+
+    context 'when both watchers return empty lists' do
+      let(:primary_healthy) { false }
+      let(:secondary_healthy) { false }
+
+      it 'returns an empty list' do
+        expect(subject.merged_backends).to eq([])
+      end
+
+      it 'calls backends on both watchers' do
+        expect(primary_watcher).to receive(:backends).exactly(:once)
+        expect(secondary_watcher).to receive(:backends).exactly(:once)
+        subject.merged_backends
+      end
+    end
+
+    context 'with secondary first in order' do
+      let(:sequential_order) { ['secondary', 'primary'] }
+
+      it 'returns secondary backends' do
+        expect(subject.merged_backends).to eq(secondary_backends)
+      end
+
+      it 'calls backends only on second watcher' do
+        expect(primary_watcher).not_to receive(:backends)
+        expect(secondary_watcher).to receive(:backends).exactly(:once)
+        subject.merged_backends
+      end
+    end
+  end
+
+  describe '#healthy?' do
+    it 'calls ping? on the first watcher' do
+      expect(primary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+      expect(primary_watcher).not_to receive(:ping?)
+      subject.healthy?
+    end
+
+    context 'when only secondary is healthy' do
+      let(:primary_healthy) { false }
+
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+
+      it 'calls ping on secondary' do
+        expect(secondary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+        subject.healthy?
+      end
+    end
+
+    context 'when only primary is healthy' do
+      let(:secondary_healthy) { false }
+
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+
+      it 'calls ping on primary' do
+        expect(primary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+        subject.healthy?
+      end
+    end
+
+    context 'when both watchers are healthy' do
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+    end
+
+    context 'when both watchers are unhealthy' do
+      let(:primary_healthy) { false }
+      let(:secondary_healthy) { false }
+
+      it 'returns false' do
+        expect(subject.healthy?).to eq(false)
+      end
+    end
+
+    context 'with reversed order' do
+      let(:sequential_order) { ['secondary', 'primary'] }
+
+      it 'calls ping? on secondary' do
+        expect(secondary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+        expect(primary_watcher).not_to receive(:ping?)
+        subject.healthy?
+      end
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/sequential_spec.rb
+++ b/spec/lib/synapse/multi_resolver/sequential_spec.rb
@@ -10,6 +10,7 @@ describe Synapse::ServiceWatcher::Resolver::SequentialResolver do
     allow(w).to receive(:backends) { primary_healthy ? primary_backends: [] }
     allow(w).to receive(:config_for_generator) { primary_healthy ? primary_config_for_generator: {} }
     allow(w).to receive(:ping?).and_return(primary_healthy)
+    allow(w).to receive(:watching?).and_return(primary_healthy)
     w
   }
   let(:primary_backends) { ["primary_1", "primary_2", "primary_3"] }
@@ -21,6 +22,7 @@ describe Synapse::ServiceWatcher::Resolver::SequentialResolver do
     allow(w).to receive(:backends) { secondary_healthy ? secondary_backends: [] }
     allow(w).to receive(:config_for_generator) { secondary_healthy ? secondary_config_for_generator: {} }
     allow(w).to receive(:ping?).and_return(secondary_healthy)
+    allow(w).to receive(:watching?).and_return(secondary_healthy)
     w
   }
   let(:secondary_backends) { ["secondary_1", "secondary_2", "secondary_3"] }
@@ -245,7 +247,7 @@ describe Synapse::ServiceWatcher::Resolver::SequentialResolver do
       end
 
       it 'picks first' do
-        expect(primary_watcher).to receive(:ping?).exactly(:once)
+        expect(primary_watcher).to receive(:ping?).at_least(:once)
         expect(primary_watcher).to receive(:backends).exactly(:once)
         expect(primary_watcher).to receive(:config_for_generator).exactly(:once)
 
@@ -266,7 +268,7 @@ describe Synapse::ServiceWatcher::Resolver::SequentialResolver do
       let(:primary_healthy) { false }
 
       it 'picks second' do
-        expect(secondary_watcher).to receive(:ping?).exactly(:once)
+        expect(secondary_watcher).to receive(:ping?).at_least(:once)
         expect(secondary_watcher).to receive(:backends).exactly(:once)
         expect(secondary_watcher).to receive(:config_for_generator).exactly(:once)
 

--- a/spec/lib/synapse/multi_resolver/union_spec.rb
+++ b/spec/lib/synapse/multi_resolver/union_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+require 'synapse/service_watcher/multi/resolver/union'
+require 'synapse/service_watcher/base/base'
+
+describe Synapse::ServiceWatcher::Resolver::UnionResolver do
+  let(:watchers) { {'primary' => primary_watcher, 'secondary' => secondary_watcher} }
+
+  let(:primary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends).and_return(primary_backends)
+    allow(w).to receive(:ping?).and_return(primary_healthy)
+    w
+  }
+  let(:primary_backends) { ["primary_1", "primary_2", "primary_3"] }
+  let(:primary_healthy) { true }
+
+  let(:secondary_watcher) {
+    w = double(Synapse::ServiceWatcher::BaseWatcher)
+    allow(w).to receive(:backends).and_return(secondary_backends)
+    allow(w).to receive(:ping?).and_return(secondary_healthy)
+    w
+  }
+  let(:secondary_backends) { ["secondary_1", "secondary_2", "secondary_3"] }
+  let(:secondary_healthy) { true }
+
+  let(:opts) { opts_valid }
+  let(:opts_valid) { {'method' => 'union'} }
+
+  subject { Synapse::ServiceWatcher::Resolver::UnionResolver.new(opts, watchers, -> {}) }
+
+  describe '#initialize' do
+    it 'constructs normally' do
+      expect { subject }.not_to raise_error
+    end
+
+    context 'with invalid arguments' do
+      let(:opts) { {'method' => 'bogus'} }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#merged_backends' do
+    it 'returns a combined unordered list of all backends' do
+      subject.merged_backends.should =~ (primary_backends + secondary_backends)
+    end
+
+    it 'calls backends on all watchers' do
+      expect(primary_watcher).to receive(:backends).exactly(:once)
+      expect(secondary_watcher).to receive(:backends).exactly(:once)
+      subject.merged_backends
+    end
+
+    context 'when one watcher returns an empty list' do
+      let(:primary_backends) { [] }
+
+      it 'returns only healthy watchers backends' do
+        subject.merged_backends.should =~ secondary_backends
+      end
+    end
+
+    context 'when duplicates exist' do
+      # duplicates should be included because they are deduplicated in
+      # set_backends.
+      let(:primary_backends) { ["primary_1"] + secondary_backends }
+
+      it 'includes duplicates' do
+        subject.merged_backends.should =~ (primary_backends + secondary_backends)
+      end
+    end
+  end
+
+  describe '#healthy?' do
+    it 'calls ping? on at least one watcher' do
+      ping_count = 0
+      allow(primary_watcher).to receive(:ping?) {
+        ping_count += 1
+        true
+      }
+      allow(secondary_watcher).to receive(:ping?) {
+        ping_count += 1
+        true
+      }
+
+      subject.healthy?
+      expect(ping_count).to be >= 1
+    end
+
+    context 'when only secondary is healthy' do
+      let(:primary_healthy) { false }
+
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+
+      it 'calls ping on secondary' do
+        expect(secondary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+        subject.healthy?
+      end
+    end
+
+    context 'when only primary is healthy' do
+      let(:secondary_healthy) { false }
+
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+
+      it 'calls ping on primary' do
+        expect(primary_watcher).to receive(:ping?).exactly(:once).and_return(true)
+        subject.healthy?
+      end
+    end
+
+    context 'when both watchers are healthy' do
+      it 'returns true' do
+        expect(subject.healthy?).to eq(true)
+      end
+    end
+
+    context 'when both watchers are unhealthy' do
+      let(:primary_healthy) { false }
+      let(:secondary_healthy) { false }
+
+      it 'returns false' do
+        expect(subject.healthy?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds in two new resolver types:
* `union` which simply merges the results of N watchers
* `sequential` which goes through the watchers in orders and returns the first non-error result

## Todo
- [x] documentation
- [x] manual tests

## Tests
- [x] unit tests
- [x] union resolver returns backends from both watchers
```bash
$ grep "server i-" haproxy.cfg
        server i-secondary_127.0.0.2:2000 127.0.0.2:2000 id 2 cookie i-secondary_127.0.0.2:2000 check inter 2s rise 3 fall 2
        server i-secondary2_127.0.0.3:2001 127.0.0.3:2001 id 1 cookie i-secondary2_127.0.0.3:2001 check inter 2s rise 3 fall 2
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 3 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
```
- [x] union resolver when one one watcher is down
Note that because the ZK watcher will retry until crashing after the limit, the hosts do not change:
```bash
$ grep "server i-" haproxy.cfg
        server i-secondary_127.0.0.2:2000 127.0.0.2:2000 id 2 cookie i-secondary_127.0.0.2:2000 check inter 2s rise 3 fall 2
        server i-secondary2_127.0.0.3:2001 127.0.0.3:2001 id 1 cookie i-secondary2_127.0.0.3:2001 check inter 2s rise 3 fall 2
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 3 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
```
- [x] sequential resolver returns primary first
```bash
$ grep "server i-" haproxy.cfg
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 3 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
```
- [x] sequential resolver when secondary is down
```bash
grep "server i-" haproxy.cfg
        server i-secondary_127.0.0.2:2000 127.0.0.2:2000 id 2 cookie i-secondary_127.0.0.2:2000 check inter 2s rise 3 fall 2
        server i-secondary2_127.0.0.3:2001 127.0.0.3:2001 id 1 cookie i-secondary2_127.0.0.3:2001 check inter 2s rise 3 fall 2
```

## Reviewers
@bsherrod 
@austin-zhu 
