### PR TITLE
Thread Safety

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -79,7 +79,6 @@ module Synapse
           end
 
           if @config_updated.get
-            @config_updated.set(false)
             statsd_increment('synapse.config.update')
             @config_generators.each do |config_generator|
               log.info "synapse: configuring #{config_generator.name}"
@@ -91,6 +90,8 @@ module Synapse
                 raise e
               end
             end
+
+            @config_updated.set(false)
           end
 
           sleep 1

--- a/lib/synapse/atomic.rb
+++ b/lib/synapse/atomic.rb
@@ -1,0 +1,20 @@
+require 'thread'
+
+module Synapse
+  class AtomicValue
+    def initialize(initial_value)
+      @mu = Mutex.new
+      set(initial_value)
+    end
+
+    def get
+      return @mu.synchronize { @value }
+    end
+
+    def set(new_value)
+      @mu.synchronize {
+        @value = new_value
+      }
+    end
+  end
+end

--- a/lib/synapse/service_watcher/base/base.rb
+++ b/lib/synapse/service_watcher/base/base.rb
@@ -43,8 +43,9 @@ class Synapse::ServiceWatcher
       @leader_election = opts['leader_election'] || false
       @leader_last_warn = Time.now - LEADER_WARN_INTERVAL
 
+      @available_generators = @synapse.available_generators
       config_for_generator = Hash[
-        @synapse.available_generators.collect do |generator_name, generator|
+        @available_generators.collect do |generator_name, generator|
           watcher_provided_config = opts[generator_name] || {}
           normalized_generator_opts = generator.normalize_watcher_provided_config(
             @name, watcher_provided_config

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -88,6 +88,10 @@ class Synapse::ServiceWatcher
       return @resolver.merged_backends
     end
 
+    def config_for_generator
+      return @resolver.merged_config_for_generator
+    end
+
     private
 
     def validate_discovery_opts
@@ -113,7 +117,7 @@ class Synapse::ServiceWatcher
     end
 
     def resolver_notification
-      set_backends(backends)
+      set_backends(backends, config_for_generator)
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -30,6 +30,10 @@ class Synapse::ServiceWatcher::MultiWatcher::Resolver
 	     # return a single list of backends
 	  end
 
+	  def merged_config_for_generator
+	     # return a single hash for generator config
+	  end
+
 	  def healthy?
 	     # return whether or not the watchers are healthy
 	  end

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -38,6 +38,11 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     # should be overridden in child classes
+    def merged_config_for_generator
+      return {}
+    end
+
+    # should be overridden in child classes
     def healthy?
       return true
     end

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -57,13 +57,15 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     def merged_backends
-      watcher_name = @watcher_setting.get
-      return @watchers[watcher_name].backends
+      return current_watcher.backends
+    end
+
+    def merged_config_for_generator
+      return current_watcher.config_for_generator
     end
 
     def healthy?
-      watcher_name = @watcher_setting.get
-      return @watchers[watcher_name].ping?
+      return current_watcher.ping?
     end
 
     def validate_opts
@@ -92,6 +94,11 @@ class Synapse::ServiceWatcher::Resolver
         @watcher_setting.set(w)
         send_notification
       end
+    end
+
+    def current_watcher
+      watcher_name = @watcher_setting.get
+      return @watchers[watcher_name]
     end
 
     # url = s3://{bucket}/{path}

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -450,7 +450,7 @@ class Synapse::ServiceWatcher
       #   each key should be named by one of the available generators
       #   each value should be a hash (could be empty)
       decoded.collect.each do |generator_name, generator_config|
-        if !@synapse.available_generators.keys.include?(generator_name)
+        if !@available_generators.keys.include?(generator_name)
           log.warn "synapse: invalid generator name in ZK node at #{@discovery['path']}:" \
             " #{generator_name}"
           next

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -1,4 +1,5 @@
 require "synapse/service_watcher/base/base"
+require 'synapse/atomic'
 
 require 'thread'
 require 'zk'
@@ -54,29 +55,33 @@ class Synapse::ServiceWatcher
       @zk_hosts = zk_host_list.join(',')
 
       @zk = nil
+      @watcher = nil
+      @thread = nil
+      @should_exit = Synapse::AtomicValue.new(false)
     end
 
     def start
-      @watcher = nil
-
       log.info "synapse: starting ZK watcher #{@name} @ cluster: #{@zk_cluster} path: #{@discovery['path']} retry policy: #{@retry_policy}"
-      zk_connect do
-        # the path must exist, otherwise watch callbacks will not work
-        with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
-          unless @zk.exists?(@discovery['path'])
-            statsd_time('synapse.watcher.zk.create_path.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
-              log.info "synapse: zk create at #{@discovery['path']} for #{attempts} times"
-              create(@discovery['path'])
-            end
-          end
-        end
 
-        watcher_callback.call
+      # Zookeeper processing is run in a background thread so that any retries
+      # do not block the main thread.
+      zk_connect do
+        @thread = Thread.new {
+          start_discovery
+
+          until @should_exit.get
+            sleep 0.5
+          end
+        }
       end
     end
 
     def stop
       log.warn "synapse: zookeeper watcher exiting"
+
+      @should_exit.set(true)
+      @thread.join unless @thread.nil?
+
       zk_teardown do
         @watcher.unsubscribe unless @watcher.nil?
         @watcher = nil
@@ -92,6 +97,20 @@ class Synapse::ServiceWatcher
     end
 
     private
+
+    def start_discovery
+      # the path must exist, otherwise watch callbacks will not work
+      with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
+        unless @zk.exists?(@discovery['path'])
+          statsd_time('synapse.watcher.zk.create_path.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
+            log.info "synapse: zk create at #{@discovery['path']} for #{attempts} times"
+            create(@discovery['path'])
+          end
+        end
+      end
+
+      watcher_callback.call
+    end
 
     # find the current backends at the discovery path
     def discover(zookeeper_opts={:watch => true})

--- a/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
@@ -52,7 +52,7 @@ class Synapse::ServiceWatcher
       zk_teardown do
         # Signal to the thread that it should exit, and then wait for it to
         # exit.
-        @should_exit.set(true) unless @should_exit.nil?
+        @should_exit.set(true)
         @thread.join unless @thread.nil?
       end
     end

--- a/spec/lib/synapse/atomic_spec.rb
+++ b/spec/lib/synapse/atomic_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+require 'synapse/atomic'
+
+describe Synapse::AtomicValue do
+  let(:initial_value) { 'mock-value' }
+  let(:internal_mu) { subject.instance_variable_get(:@mu) }
+
+  subject { Synapse::AtomicValue.new(initial_value) }
+
+  describe '#initialize' do
+    it 'creates successfully' do
+      expect { subject }.not_to raise_error
+    end
+
+    it 'sets the initial value' do
+      expect(subject.get).to eq(initial_value)
+    end
+
+    context 'without a provided value' do
+      it 'raises an error' do
+        expect { Synapse::AtomicValue.new }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe '#get' do
+    let(:value) { 'new-value' }
+
+    before :each do
+      subject.instance_variable_set(:@value, value)
+    end
+
+    it 'returns the internal value' do
+      expect(subject.get).to eq(value)
+    end
+
+    it 'holds a lock' do
+      expect(internal_mu).to receive(:synchronize).exactly(:once)
+      subject.get
+    end
+
+    it 'releases lock after call' do
+      expect(internal_mu.locked?).to eq(false)
+      subject.get
+    end
+
+    context 'after a set' do
+      it 'returns the new value' do
+        subject.set(value)
+        expect(subject.get).to eq(value)
+      end
+    end
+  end
+
+  describe '#set' do
+    let(:value) { 'new-value' }
+
+    it 'sets the internal value' do
+      expect { subject.set(value) }
+        .to change { subject.instance_variable_get(:@value) }
+        .from(initial_value).to(value)
+    end
+
+    it 'holds a lock' do
+      expect(internal_mu).to receive(:synchronize).exactly(:once)
+      subject.set(value)
+    end
+
+    it 'releases lock after call' do
+      expect(internal_mu.locked?).to eq(false)
+      subject.set(value)
+    end
+  end
+end

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -63,6 +63,12 @@ describe Synapse::ServiceWatcher::Resolver::BaseResolver do
     end
   end
 
+  describe "#merged_config_for_generator" do
+    it 'returns an empty config by default' do
+      expect(subject.merged_config_for_generator).to eq({})
+    end
+  end
+
   describe "#healthy?" do
     it 'returns true by default' do
       expect(subject.healthy?).to eq(true)

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -124,7 +124,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
   describe '#merged_backends' do
     before :each do
-      subject.instance_variable_set(:@watcher_setting, 'secondary')
+      subject.instance_variable_get(:@watcher_setting).set('secondary')
     end
 
     it 'calls #backends on current watcher' do
@@ -144,7 +144,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
   describe '#healthy?' do
     before :each do
-      subject.instance_variable_set(:@watcher_setting, 'secondary')
+      subject.instance_variable_get(:@watcher_setting).set('secondary')
     end
 
     it 'calls #ping? on current watcher' do
@@ -191,7 +191,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
   describe 'set_watcher' do
     before :each do
-      subject.instance_variable_set(:@watcher_setting, 'primary')
+      subject.instance_variable_get(:@watcher_setting).set('primary')
     end
 
     it 'sends a notification' do
@@ -201,7 +201,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
 
     it 'sets @watcher_setting' do
       subject.send(:set_watcher, 'secondary')
-      expect(subject.instance_variable_get(:@watcher_setting)).to eq('secondary')
+      expect(subject.instance_variable_get(:@watcher_setting).get).to eq('secondary')
     end
 
     context 'with same watcher' do
@@ -214,7 +214,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
     context 'with unknown watchers' do
       it 'does not change @watcher_setting' do
         expect { subject.send(:set_watcher, 'bogus-watcher') }
-          .not_to change { subject.instance_variable_get(:@watcher_setting) }
+          .not_to change { subject.instance_variable_get(:@watcher_setting).get }
       end
 
       it 'does not send a notification' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -527,7 +527,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
 
         it 'sets a default' do
           expect { subject }.not_to raise_error
-          expect(subject.instance_variable_get(:@discovery)['polling_interval_sec'].nil?).to be(false)
+          expect(subject.instance_variable_get(:@poll_interval).nil?).to be(false)
         end
       end
 


### PR DESCRIPTION
## Summary
The new ZookeeperPoll watcher runs in a background thread and needs to communicate with the main thread (in order to tell it when to update). Currently, it just calls a callback which will execute in the background thread, and that has some thread safety concerns.

Also, the main thread will read the state of each watcher. The fixes for this are:

1. Hold a Synapse-level lock when reconfiguring.
2. Hold a watcher-level lock when getting/setting any watcher state.

In addition, it runs the primary Zookeeper watcher in a background thread. This allows retry logic to *not* block the main thread.

## Tests
- [x] unit tests
- [x] basic testing: running Synapse with multiple watchers
- [x] basic Zookeeper watcher still works
```bash
$ grep server haproxy.cfg
        timeout  server  1m
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 2 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
        server default1_localhost:8422 localhost:8422 id 1 cookie default1_localhost:8422 check inter 2s rise 3 fall 2

$ zookeepercli -servers localhost:2181 -c create /services/service1/0002.mango-test '{"host":"127.0.0.3","port":1003,"name":"i-primary3","labels":{"region":"us-east-1","az":"us-east-1c"}}'

$ grep server haproxy.cfg                                                                timeout  server  1m
        server i-primary3_127.0.0.3:1003 127.0.0.3:1003 id 1 cookie i-primary3_127.0.0.3:1003 check inter 2s rise 3 fall 2
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 2 cookie i-primary_127.0.0.1:1000 check inter 2s rise 3 fall 2
        server default1_localhost:8422 localhost:8422 id 1 cookie default1_localhost:8422 check inter 2s rise 3 fall 2
```
- additional testing will be performed as part of mega-PR #311 

## Reviewers
@austin-zhu 