### PR TITLE
Resolve service-level configuration in MultiWatcher

### DIFF
--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -117,7 +117,7 @@ class Synapse::ServiceWatcher
     end
 
     def resolver_notification
-      set_backends(backends)
+      set_backends(backends, config_for_generator)
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -88,6 +88,10 @@ class Synapse::ServiceWatcher
       return @resolver.merged_backends
     end
 
+    def config_for_generator
+      return @resolver.merged_config_for_generator
+    end
+
     private
 
     def validate_discovery_opts

--- a/lib/synapse/service_watcher/multi/resolver/README.md
+++ b/lib/synapse/service_watcher/multi/resolver/README.md
@@ -30,6 +30,10 @@ class Synapse::ServiceWatcher::MultiWatcher::Resolver
 	     # return a single list of backends
 	  end
 
+	  def merged_config_for_generator
+	     # return a single hash for generator config
+	  end
+
 	  def healthy?
 	     # return whether or not the watchers are healthy
 	  end

--- a/lib/synapse/service_watcher/multi/resolver/base.rb
+++ b/lib/synapse/service_watcher/multi/resolver/base.rb
@@ -38,6 +38,11 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     # should be overridden in child classes
+    def merged_config_for_generator
+      return {}
+    end
+
+    # should be overridden in child classes
     def healthy?
       return true
     end

--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -57,13 +57,15 @@ class Synapse::ServiceWatcher::Resolver
     end
 
     def merged_backends
-      watcher_name = @watcher_setting.get
-      return @watchers[watcher_name].backends
+      return current_watcher.backends
+    end
+
+    def merged_config_for_generator
+      return current_watcher.config_for_generator
     end
 
     def healthy?
-      watcher_name = @watcher_setting.get
-      return @watchers[watcher_name].ping?
+      return current_watcher.ping?
     end
 
     def validate_opts
@@ -92,6 +94,11 @@ class Synapse::ServiceWatcher::Resolver
         @watcher_setting.set(w)
         send_notification
       end
+    end
+
+    def current_watcher
+      watcher_name = @watcher_setting.get
+      return @watchers[watcher_name]
     end
 
     # url = s3://{bucket}/{path}

--- a/spec/lib/synapse/multi_resolver/base_spec.rb
+++ b/spec/lib/synapse/multi_resolver/base_spec.rb
@@ -63,6 +63,12 @@ describe Synapse::ServiceWatcher::Resolver::BaseResolver do
     end
   end
 
+  describe "#merged_config_for_generator" do
+    it 'returns an empty config by default' do
+      expect(subject.merged_config_for_generator).to eq({})
+    end
+  end
+
   describe "#healthy?" do
     it 'returns true by default' do
       expect(subject.healthy?).to eq(true)

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -298,13 +298,15 @@ describe Synapse::ServiceWatcher::MultiWatcher do
   describe "resolver" do
     context 'when resolver sends a notification' do
       let(:mock_backends) { ['host_1', 'host_2'] }
+      let(:mock_config) { {'haproxy' => 'mock config'} }
 
       it 'sets backends to resolver backends' do
         expect(subject).to receive(:resolver_notification).exactly(:once).and_call_original
-        expect(subject).to receive(:set_backends).exactly(:once).with(mock_backends)
+        expect(subject).to receive(:set_backends).exactly(:once).with(mock_backends, mock_config)
 
         resolver = subject.instance_variable_get(:@resolver)
         allow(resolver).to receive(:merged_backends).exactly(:once).and_return(mock_backends)
+        allow(resolver).to receive(:merged_config_for_generator).exactly(:once).and_return(mock_config)
 
         resolver.send(:send_notification)
       end

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -260,17 +260,19 @@ describe Synapse::ServiceWatcher::MultiWatcher do
   end
 
   describe ".backends" do
-    it "calls resolver.merged_backends" do
+    it "returns resolver.merged_backends" do
       resolver = subject.instance_variable_get(:@resolver)
-      expect(resolver).to receive(:merged_backends)
-      subject.backends
-    end
-
-    it "returns resolver.merged_backends result" do
-      resolver = subject.instance_variable_get(:@resolver)
-      allow(resolver).to receive(:merged_backends).and_return(["test-a", "test-b"])
+      expect(resolver).to receive(:merged_backends).exactly(:once).and_return(["test-a", "test-b"])
       expect(subject.backends).to eq(["test-a", "test-b"])
     end
+  end
+
+  describe ".config_for_generator" do
+    it 'calls resolver.merged_config_for_generator' do
+      resolver = subject.instance_variable_get(:@resolver)
+      expect(resolver).to receive(:merged_config_for_generator).exactly(:once).and_return({'haproxy' => 'custom config'})
+      expect(subject.config_for_generator).to eq({'haproxy' => 'custom config'})
+      end
   end
 
   describe ".ping?" do


### PR DESCRIPTION
## Summary
The `MultiWatcher` resolvers only work on the backends currently. This ensures that service-level config is also considered.

### Current State
Even though service-level config is set in Zookeeper, it does not appear in the generated HAProxy config.

```bash
$ zookeepercli -servers localhost:2181 -c get /services/service1 {"haproxy":{"server_options":"check port %{port} inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file ... ...","listen":["mode http","option tcp-check","cookie SRVID insert indirect nocache","option httplog"],"port":6009,"backend":["option http-server-close"],"frontend":["bind ::1:6009"]}}

$ cat haproxy.cfg
...
frontend service1
        mode http
        bind localhost:3213 ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305
        default_backend service1

backend service1
        mode http
        option httpchk /health
        http-check expect string OK
        server i-secondary2_127.0.0.3:2001 127.0.0.3:2001 id 1 cookie i-secondary2_127.0.0.3:2001 check inter 2s rise 3 fall 2
        server i-secondary_127.0.0.2:2000 127.0.0.2:2000 id 2 cookie i-secondary_127.0.0.2:2000 check inter 2s rise 3 fall 2%
```

## Tests
- [x] unit tests
- [x] service level config from primary appears
```
frontend service1
        bind ::1:6009
        mode http
        option httplog
        bind localhost:6009
        default_backend service1

backend service1
        option http-server-close
        mode http
        option tcp-check
        cookie SRVID insert indirect nocache
        option httplog
        server i-primary_127.0.0.1:1000 127.0.0.1:1000 id 1 cookie i-primary_127.0.0.1:1000 check port 1000 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file ...
        server i-primary3_127.0.0.3:1003 127.0.0.3:1003 id 2 cookie i-primary3_127.0.0.3:1003 check port 1003 inter 30s downinter 1s rise 1 fall 2 ssl verify required ca-file ...
```

- [x] after switching on S3, service-level config from secondary appears
```bash
$ AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin aws --endpoint-url http://localhost:9000 s3 cp s3-toggle-resolver.yaml s3://synapse-test/s3-toggle-resolver.yaml
upload: ./s3-toggle-resolver.yaml to s3://synapse-test/s3-toggle-resolver.yaml
$ cat haproxy.cfg
...
frontend service1
        bind ::1:6010
        mode http
        option httplog
        bind localhost:6010 # <-- note that the port is different, 6010 instead of 6009
        default_backend service1
```

## Reviewers
@austin-zhu @bsherrod 