### PR TITLE
Add ZookeeperDnsPollWatcher

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -135,7 +135,7 @@ module Synapse
     private
     def create_service_watchers(services={})
       service_watchers = []
-      reconfigure_callback = -> { reconfigure! }
+      reconfigure_callback = ->(*args) { reconfigure! }
 
       services.each do |service_name, service_config|
         if service_config.has_key?('load_test_concurrency')

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -78,7 +78,7 @@ module Synapse
             raise "synapse: service watcher #{w.name} failed ping!" unless alive
           end
 
-          if @config_updated.get
+          if @config_updated.get_and_set(false)
             statsd_increment('synapse.config.update')
             @config_generators.each do |config_generator|
               log.info "synapse: configuring #{config_generator.name}"
@@ -90,8 +90,6 @@ module Synapse
                 raise e
               end
             end
-
-            @config_updated.set(false)
           end
 
           sleep 1

--- a/lib/synapse/atomic.rb
+++ b/lib/synapse/atomic.rb
@@ -16,5 +16,13 @@ module Synapse
         @value = new_value
       }
     end
+
+    def get_and_set(new_value)
+      return @mu.synchronize {
+        original_value = @value
+        @value = new_value
+        original_value
+      }
+    end
   end
 end

--- a/lib/synapse/service_watcher/base/base.rb
+++ b/lib/synapse/service_watcher/base/base.rb
@@ -254,7 +254,7 @@ class Synapse::ServiceWatcher
     # can be overridden in subclasses.
     def reconfigure!
       @revision += 1
-      @reconfigure_callback.call
+      @reconfigure_callback.call(backends, config_for_generator, @revision)
     end
   end
 end

--- a/lib/synapse/service_watcher/multi/multi.rb
+++ b/lib/synapse/service_watcher/multi/multi.rb
@@ -48,7 +48,7 @@ class Synapse::ServiceWatcher
         discovery_method = watcher_config['method']
 
         log.info "synapse multi-watcher creating child watcher #{watcher_name} of type #{discovery_method}"
-        watcher = Synapse::ServiceWatcher.load_watcher(discovery_method, merged_config, synapse, -> { reconfigure! })
+        watcher = Synapse::ServiceWatcher.load_watcher(discovery_method, merged_config, synapse, ->(*args) { reconfigure! })
 
         @watchers[watcher_name] = watcher
       end

--- a/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
@@ -185,11 +185,13 @@ class Synapse::ServiceWatcher
       Synapse::ServiceWatcher::ZookeeperWatcher.new(
         mk_child_watcher_opts(zookeeper_discovery_opts),
         @synapse,
-        -> {
-          queue.push(Messages::NewServers.new(@backends))
-          reconfigure!
-        },
+        ->(backends, *args) { update_dns_watcher(queue, backends) },
       )
+    end
+
+    def update_dns_watcher(queue, backends)
+      queue.push(Messages::NewServers.new(backends))
+      reconfigure!
     end
 
     def validate_discovery_opts

--- a/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
@@ -1,4 +1,5 @@
 require 'synapse/service_watcher/base/base'
+require 'synapse/service_watcher/zookeeper_dns/zookeeper_dns'
 require 'synapse/service_watcher/zookeeper_poll/zookeeper_poll'
 
 require 'thread'

--- a/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
@@ -14,10 +14,7 @@ class Synapse::ServiceWatcher
       Synapse::ServiceWatcher::ZookeeperPollWatcher.new(
         mk_child_watcher_opts(zookeeper_discovery_opts),
         @synapse,
-        -> {
-          queue.push(Messages::NewServers.new(@backends))
-          reconfigure!
-        },
+        ->(backends, *args) { update_dns_watcher(queue, backends) },
       )
     end
 

--- a/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
@@ -1,0 +1,38 @@
+require 'synapse/service_watcher/base/base'
+require 'synapse/service_watcher/zookeeper_poll/zookeeper_poll'
+
+require 'thread'
+
+class Synapse::ServiceWatcher
+  class ZookeeperDnsPollWatcher < ZookeeperDnsWatcher
+    def make_zookeeper_watcher(queue)
+      zookeeper_discovery_opts = @discovery.select do |k,_|
+        k == 'hosts' || k == 'path' || k == 'label_filter' || k == 'polling_interval_sec'
+      end
+      zookeeper_discovery_opts['method'] = 'zookeeper_poll'
+
+      Synapse::ServiceWatcher::ZookeeperPollWatcher.new(
+        mk_child_watcher_opts(zookeeper_discovery_opts),
+        @synapse,
+        -> {
+          queue.push(Messages::NewServers.new(@backends))
+          reconfigure!
+        },
+      )
+    end
+
+    def validate_discovery_opts
+      unless @discovery['method'] == 'zookeeper_dns_poll'
+        raise ArgumentError, "invalid discovery method #{@discovery['method']}; expecting zookeeper_dns_poll"
+      end
+
+      unless @discovery['hosts']
+        raise ArgumentError, "missing or invalid zookeeper host for service #{@name}"
+      end
+
+      unless @discovery['path']
+        raise ArgumentError, "invalid zookeeper path for service #{@name}"
+      end
+    end
+  end
+end

--- a/spec/lib/synapse/service_watcher_ec2tags_spec.rb
+++ b/spec/lib/synapse/service_watcher_ec2tags_spec.rb
@@ -39,7 +39,7 @@ describe Synapse::ServiceWatcher::Ec2tagWatcher do
     allow(mock_synapse).to receive(:reconfigure!).and_return(true)
     mock_synapse
   end
-  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse, -> {}) }
+  subject { Synapse::ServiceWatcher::Ec2tagWatcher.new(basic_config, mock_synapse, ->(*args) {}) }
 
   let(:basic_config) do
     { 'name' => 'ec2tagtest',

--- a/spec/lib/synapse/service_watcher_multi_spec.rb
+++ b/spec/lib/synapse/service_watcher_multi_spec.rb
@@ -18,7 +18,7 @@ describe Synapse::ServiceWatcher::MultiWatcher do
     Synapse::ServiceWatcher::MultiWatcher.new(config, mock_synapse, reconfigure_callback)
   }
 
-  let(:reconfigure_callback) { -> {} }
+  let(:reconfigure_callback) { ->(*args) {} }
 
   let(:discovery) do
     valid_discovery

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -3,8 +3,9 @@ require 'active_support/all'
 require 'active_support/testing/time_helpers'
 
 require 'synapse/service_watcher/zookeeper/zookeeper'
-require 'synapse/service_watcher/zookeeper_dns/zookeeper_dns'
 require 'synapse/service_watcher/zookeeper_poll/zookeeper_poll'
+require 'synapse/service_watcher/zookeeper_dns/zookeeper_dns'
+require 'synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll'
 
 describe Synapse::ServiceWatcher::ZookeeperWatcher do
   let(:mock_synapse) do
@@ -497,58 +498,6 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     end
   end
 
-  describe 'ZookeeperDnsWatcher' do
-    let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => ['somehost'],'path' => 'some/path' } }
-
-    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher.new(config, mock_synapse, -> {}) }
-    let(:mock_zk) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper) }
-    let(:mock_dns) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns) }
-
-    it 'creates child watchers' do
-      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper).to receive(:new).exactly(:once).and_return(mock_zk)
-      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).and_return(mock_dns)
-      expect(mock_zk).to receive(:start).exactly(:once)
-      expect(mock_dns).to receive(:start).exactly(:once)
-      expect(Thread).to receive(:new).exactly(:once)
-
-      subject.start
-    end
-
-    describe 'make_zookeeper_watcher' do
-      let(:mock_queue) { double(Queue) }
-
-      it 'creates a ZK watcher' do
-        expect(subject.send(:make_zookeeper_watcher, mock_queue)).to be_kind_of(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper)
-      end
-
-      it 'creates a ZK watcher with proper reconfigure' do
-        zk = subject.send(:make_zookeeper_watcher, mock_queue)
-
-        expect(mock_queue).to receive(:push).with(kind_of(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Messages::NewServers))
-        expect(subject).to receive(:reconfigure!).exactly(:once)
-        zk.send(:reconfigure!)
-      end
-    end
-
-    # describe Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper do
-    #   let(:mock_cb) { -> { } }
-    #   subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher::Zookeeper.new(config, nil, mock_synapse, mock_cb, []) }
-
-    #   it 'decodes data correctly' do
-    #     expect(subject.send(:deserialize_service_instance, service_data_string)).to eql(deserialized_service_data)
-    #   end
-
-    #   describe 'reconfigure!' do
-    #     it 'calls provided callback' do
-    #       expect(mock_cb).to receive(:call).exactly(:once)
-    #       subject.send(:reconfigure!)
-    #     end
-    #   end
-    # end
-  end
-
-  # TODO: ZookeeperDnsPollWatcher
-
   describe Synapse::ServiceWatcher::ZookeeperPollWatcher do
     let(:mock_zk) {
       zk = double("zookeeper")
@@ -851,6 +800,74 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
             subject.send(:discover)
           end
         end
+      end
+    end
+  end
+
+  describe 'ZookeeperDnsWatcher' do
+    let(:discovery) { { 'method' => 'zookeeper_dns', 'hosts' => ['somehost'],'path' => 'some/path' } }
+
+    subject { Synapse::ServiceWatcher::ZookeeperDnsWatcher.new(config, mock_synapse, -> {}) }
+    let(:mock_zk) { double(Synapse::ServiceWatcher::ZookeeperWatcher) }
+    let(:mock_dns) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns) }
+
+    it 'creates child watchers' do
+      expect(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).exactly(:once).and_return(mock_zk)
+      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).and_return(mock_dns)
+      expect(mock_zk).to receive(:start).exactly(:once)
+      expect(mock_dns).to receive(:start).exactly(:once)
+      expect(Thread).to receive(:new).exactly(:once)
+
+      subject.start
+    end
+
+    describe 'make_zookeeper_watcher' do
+      let(:mock_queue) { double(Queue) }
+
+      it 'creates a ZK watcher' do
+        expect(subject.send(:make_zookeeper_watcher, mock_queue)).to be_kind_of(Synapse::ServiceWatcher::ZookeeperWatcher)
+      end
+
+      it 'creates a ZK watcher with proper reconfigure' do
+        zk = subject.send(:make_zookeeper_watcher, mock_queue)
+
+        expect(mock_queue).to receive(:push).with(kind_of(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Messages::NewServers))
+        expect(subject).to receive(:reconfigure!).exactly(:once)
+        zk.send(:reconfigure!)
+      end
+    end
+  end
+
+  describe 'ZookeeperDnsPollWatcher' do
+    let(:discovery) { { 'method' => 'zookeeper_dns_poll', 'hosts' => ['somehost'], 'path' => 'some/path' } }
+
+    subject { Synapse::ServiceWatcher::ZookeeperDnsPollWatcher.new(config, mock_synapse, -> {}) }
+    let(:mock_zk) { double(Synapse::ServiceWatcher::ZookeeperPollWatcher) }
+    let(:mock_dns) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns) }
+
+    it 'creates child watchers' do
+      expect(Synapse::ServiceWatcher::ZookeeperPollWatcher).to receive(:new).exactly(:once).and_return(mock_zk)
+      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).and_return(mock_dns)
+      expect(mock_zk).to receive(:start).exactly(:once)
+      expect(mock_dns).to receive(:start).exactly(:once)
+      expect(Thread).to receive(:new).exactly(:once)
+
+      subject.start
+    end
+
+    describe 'make_zookeeper_watcher' do
+      let(:mock_queue) { double(Queue) }
+
+      it 'creates a ZK watcher' do
+        expect(subject.send(:make_zookeeper_watcher, mock_queue)).to be_kind_of(Synapse::ServiceWatcher::ZookeeperPollWatcher)
+      end
+
+      it 'creates a ZK watcher with proper reconfigure' do
+        zk = subject.send(:make_zookeeper_watcher, mock_queue)
+
+        expect(mock_queue).to receive(:push).with(kind_of(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Messages::NewServers))
+        expect(subject).to receive(:reconfigure!).exactly(:once)
+        zk.send(:reconfigure!)
       end
     end
   end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -102,6 +102,40 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(subject.send(:parse_service_config, config_for_generator_invalid_string)).to eql(parsed_config_for_generator_invalid)
     end
 
+    context 'with skipGc => true from cron job' do
+      let(:service_data) {
+        {
+          'host' => 'server',
+          'port' => '8888',
+          'name' => 'server',
+          'weight' => '1',
+          'haproxy_server_options' => 'backup',
+          'labels' => { 'az' => 'us-east-1a' },
+          'skipGc' => true,
+        }
+      }
+
+      let(:backend) {
+        {
+          'name' => 'server',
+          'host' => 'server',
+          'port' => '8888',
+          'labels' => {
+            'az' => 'us-east-1a'
+          },
+          'weight' => '1',
+          'haproxy_server_options' => 'backup',
+          'id' => 5
+        }
+      }
+
+      it 'decodes properly' do
+        deserialized = subject.send(:deserialize_service_instance, service_data_string)
+        expect(deserialized).to eq(deserialized_service_data)
+        expect(subject.send(:create_backend_info, 'i-xxxxxxx_0000000005', deserialized)).to eq(backend)
+      end
+    end
+
     it 'reacts to zk push events' do
       expect(subject).to receive(:watch)
       expect(subject).to receive(:discover).and_call_original

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -102,7 +102,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       expect(subject.send(:parse_service_config, config_for_generator_invalid_string)).to eql(parsed_config_for_generator_invalid)
     end
 
-    context 'with skipGc => true from cron job' do
+    context 'with unknown fields' do
       let(:service_data) {
         {
           'host' => 'server',


### PR DESCRIPTION
## Summary
Adds in the `ZookeeperDnsPollWatcher`, which is a combination of the `ZookeeperPollWatcher` and the `DnsWatcher`.

This is accomplished in part by refactoring the original `ZookeeperDnsWatcher`.

Note: this also contains a slightly unrelated new test: the `skipGc` flag from the cleanup cron job.

## Tests
- [x] unit tests
- [x] manual testing:

#### ZookeeperDnsWatcher
```bash
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-dns.json &
$ zookeepercli -servers localhost:2181 -c get /services/service-dns/0001.dns-test
{"host": "google.com", "port": 1000, "name": "i-dns"}
$ grep "server i-" haproxy.cfg
        server i-dns_2607:F8B0:4005:805::200E:1000 2607:F8B0:4005:805::200E:1000 id 2 cookie i-dns_2607:F8B0:4005:805::200E:1000 check inter 2s rise 3 fall 2
        server i-dns_216.58.194.206:1000 216.58.194.206:1000 id 1 cookie i-dns_216.58.194.206:1000 check inter 2s rise 3 fall 2
$ zookeepercli -servers localhost:2181 -c create /services/service-dns/0002.dns-test '{"host": "airbnb.com", "port": 1001, "name": "i-dns2"}'
$ grep "server i-" haproxy.cfg  | wc -l
5
$ zookeepercli -servers localhost:2181 -c rm /services/service-dns/0002.dns-test
$ grep "server i-" haproxy.cfg  | wc -l
2
```

_Synapse log_:
```
I, [2020-04-10T16:54:14.616228 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovering backends for service service1
I, [2020-04-10T16:54:14.616267 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zk list children at /services/service-dns for 1 times
I, [2020-04-10T16:54:14.617408 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: zk get parent at /services/service-dns for 1 times
I, [2020-04-10T16:54:14.617900 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: discovered 1 backends for service service1
I, [2020-04-10T16:54:14.617931 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperWatcher: synapse: no config_for_generator data from service1 for service service1; keep existing config_for_generator
I, [2020-04-10T16:54:14.739974 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns: synapse: discovered 2 backends for service service1
I, [2020-04-10T16:54:14.740073 #50310]  INFO -- Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns: synapse: no config_for_generator data from service1 for service service1; keep existing config_for_generator
```

#### ZookeeperDnsPollWatcher
```bash
$ RUBYLIB=lib bin/synapse -c ~/test-config/synapse/synapse-dns-poll.json &
$ zookeepercli -servers localhost:2181 -c get /services/service-dns/0001.dns-test
{"host": "google.com", "port": 1000, "name": "i-dns"}
$ grep "server i-" haproxy.cfg
        server i-dns_2607:F8B0:4005:805::200E:1000 2607:F8B0:4005:805::200E:1000 id 2 cookie i-dns_2607:F8B0:4005:805::200E:1000 check inter 2s rise 3 fall 2
        server i-dns_216.58.194.206:1000 216.58.194.206:1000 id 1 cookie i-dns_216.58.194.206:1000 check inter 2s rise 3 fall 2
$ zookeepercli -servers localhost:2181 -c create /services/service-dns/0002.dns-test '{"host": "airbnb.com", "port": 1001, "name": "i-dns2"}'
$ grep "server i-" haproxy.cfg  | wc -l
5
$ zookeepercli -servers localhost:2181 -c rm /services/service-dns/0002.dns-test
$ grep "server i-" haproxy.cfg  | wc -l
2
```

_Synapse log_:
```
I, [2020-04-10T17:19:24.424867 #465]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: discovered 1 backends for service service1
I, [2020-04-10T17:19:24.424957 #465]  INFO -- Synapse::ServiceWatcher::ZookeeperPollWatcher: synapse: no config_for_generator data from service1 for service service1; keep existing config_for_generator
I, [2020-04-10T17:19:24.483520 #465]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-04-10T17:19:24.483929 #465]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because config_for_generator changed. before: {}, after: {"server_options"=>"check inter 2s rise 3 fall 2", "server_port_override"=>nil, "backend"=>[], "frontend"=>[], "listen"=>["mode http", "option httpchk /health", "http-check expect string OK"], "port"=>3213, "bind_options"=>"ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305"}
I, [2020-04-10T17:19:24.484293 #465]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: could not open haproxy config file at haproxy.cfg
I, [2020-04-10T17:19:24.484581 #465]  INFO -- Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns: synapse: discovered 2 backends for service service1
I, [2020-04-10T17:19:24.484620 #465]  INFO -- Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns: synapse: no config_for_generator data from service1 for service service1; keep existing config_for_generator
I, [2020-04-10T17:19:24.484676 #465]  INFO -- Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns: calling reconfigure on #<Synapse::ServiceWatcher::ZookeeperDnsPollWatcher:0x007fea5081c120>
I, [2020-04-10T17:19:25.550747 #465]  INFO -- Synapse::Synapse: synapse: configuring haproxy
I, [2020-04-10T17:19:25.551340 #465]  INFO -- Synapse::ConfigGenerator::Haproxy: synapse: restart required because config_for_generator changed. before: {}, after: {"server_options"=>"check inter 2s rise 3 fall 2", "server_port_override"=>nil, "backend"=>[], "frontend"=>[], "listen"=>["mode http", "option httpchk /health", "http-check expect string OK"], "port"=>3213, "bind_options"=>"ssl no-sslv3 crt /path/to/cert/example.pem ciphers ECDHE-ECDSA-CHACHA20-POLY1305"}
```

## Reviewers
@austin-zhu @bsherrod 