### PR TITLE
ZookeeperDnsWatcher: fix use_previous_backends

### DIFF
--- a/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
@@ -226,6 +226,7 @@ class Synapse::ServiceWatcher
         'name' => @name,
         'discovery' => discovery_opts,
         'default_servers' => @default_servers,
+        'use_previous_backends' => @use_previous_backends,
       }
     end
   end

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.1"
+  VERSION = "0.18.2"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -845,14 +845,26 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     let(:mock_zk) { double(Synapse::ServiceWatcher::ZookeeperWatcher) }
     let(:mock_dns) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns) }
 
-    it 'creates child watchers' do
-      expect(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).exactly(:once).and_return(mock_zk)
-      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).and_return(mock_dns)
-      expect(mock_zk).to receive(:start).exactly(:once)
-      expect(mock_dns).to receive(:start).exactly(:once)
-      expect(Thread).to receive(:new).exactly(:once)
+    context 'with base watcher options' do
+      let(:use_previous_backends) { double('bool') }
+      let(:config) {
+        {
+          'name' => 'test',
+          'haproxy' => {},
+          'discovery' => discovery,
+          'use_previous_backends' => use_previous_backends,
+        }
+      }
 
-      subject.start
+      it 'passes all options to children watchers' do
+        expect(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).exactly(:once).with({'name' => 'test', 'discovery' => {'hosts' => discovery['hosts'], 'path' => discovery['path'], 'method' => 'zookeeper'}, 'default_servers' => [], 'use_previous_backends' => use_previous_backends}, anything, anything).and_return(mock_zk)
+        expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).with({'name' => 'test', 'discovery' => {}, 'default_servers' => [], 'use_previous_backends' => use_previous_backends}, anything, anything, anything, anything).and_return(mock_dns)
+        expect(mock_zk).to receive(:start).exactly(:once)
+        expect(mock_dns).to receive(:start).exactly(:once)
+        expect(Thread).to receive(:new).exactly(:once)
+
+        subject.start
+      end
     end
 
     describe 'make_zookeeper_watcher' do
@@ -881,14 +893,26 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
     let(:mock_zk) { double(Synapse::ServiceWatcher::ZookeeperPollWatcher) }
     let(:mock_dns) { double(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns) }
 
-    it 'creates child watchers' do
-      expect(Synapse::ServiceWatcher::ZookeeperPollWatcher).to receive(:new).exactly(:once).and_return(mock_zk)
-      expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).and_return(mock_dns)
-      expect(mock_zk).to receive(:start).exactly(:once)
-      expect(mock_dns).to receive(:start).exactly(:once)
-      expect(Thread).to receive(:new).exactly(:once)
+        context 'with base watcher options' do
+      let(:use_previous_backends) { double('bool') }
+      let(:config) {
+        {
+          'name' => 'test',
+          'haproxy' => {},
+          'discovery' => discovery,
+          'use_previous_backends' => use_previous_backends,
+        }
+      }
 
-      subject.start
+      it 'passes all options to children watchers' do
+        expect(Synapse::ServiceWatcher::ZookeeperPollWatcher).to receive(:new).exactly(:once).with({'name' => 'test', 'discovery' => {'hosts' => discovery['hosts'], 'path' => discovery['path'], 'method' => 'zookeeper_poll'}, 'default_servers' => [], 'use_previous_backends' => use_previous_backends}, anything, anything).and_return(mock_zk)
+        expect(Synapse::ServiceWatcher::ZookeeperDnsWatcher::Dns).to receive(:new).exactly(:once).with({'name' => 'test', 'discovery' => {}, 'default_servers' => [], 'use_previous_backends' => use_previous_backends}, anything, anything, anything, anything).and_return(mock_dns)
+        expect(mock_zk).to receive(:start).exactly(:once)
+        expect(mock_dns).to receive(:start).exactly(:once)
+        expect(Thread).to receive(:new).exactly(:once)
+
+        subject.start
+      end
     end
 
     describe 'make_zookeeper_watcher' do


### PR DESCRIPTION
## Summary

`ZookeeperDnsWatcher` was not passing the `use_previous_backends` setting to the children watchers, which meant in the children it was using the default value of `true` (even if the original watcher was provided a value of `false`).

I did not touch the other options because I'm not sure what the effect would be of adding _all_ the options in.

## Tests

- [x] CI

## Reviewers
@austin-zhu 