### PR TITLE
Set explicit zk session timeout

### DIFF
--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -392,7 +392,9 @@ class Synapse::ServiceWatcher
             # https://github.com/zk-ruby/zookeeper/blob/80a88e3179fd1d526f7e62a364ab5760f5f5da12/ext/zkrb.c
             @@zk_pool[@zk_hosts] = with_retry(@retry_policy.merge({'retriable_errors' => RuntimeError})) do |attempts|
                 log.info "synapse: creating pooled connection to #{@zk_hosts} for #{attempts} times"
-                ZK.new(@zk_hosts, :timeout => 5, :thread => :per_callback)
+                # zk session timeout is 2 * receive_timeout_msec (as of zookeeper-1.4.x) 
+                # i.e. 18000 means 36 sec
+                ZK.new(@zk_hosts, :timeout => 5, :receive_timeout_msec => 18000, :thread => :per_callback)
             end
             @@zk_pool_count[@zk_hosts] = 1
             log.info "synapse: successfully created zk connection to #{@zk_hosts}"

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.2"
+  VERSION = "0.18.3"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -611,7 +611,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         expect(ZK)
           .to receive(:new)
           .exactly(:once)
-          .with('somehost', :timeout => 5, :thread => :per_callback)
+          .with('somehost', :timeout => 5, :receive_timeout_msec => 18000, :thread => :per_callback)
           .and_return(mock_zk)
 
         subject.start


### PR DESCRIPTION
### Summary

Synapse does not specify explicit value for session timeout. By default ruby client uses RECEIVE_TIMEOUT=10000ms which leads to 20-sec session in zk server.

https://github.com/zk-ruby/zookeeper/blob/master/ext/c_zookeeper.rb#L20

The PR sets synapse session timeout to be 36-sec. 

### Test
- unit tests: bundle exec rspec
- To verify that zk session is set to 36-sec, manual integration test was executed with zk server: 
  - created an instance of client connecting to test zk server. 
  - used 4-letter commands to dump connections on zk server: `echo cons | nc localhost 2181 > cons.txt`
  - verified the output that connection had 36-sec session with to=36001: 
`/172.18.26.75:53573[1](queued=0,recved=2,sent=2,sid=0x66055392eb24038e,lop=PING,est=1594240596217,to=36001,lcxid=0x0,lzxid=0xffffffffffffffff,lresp=22948687231,llat=1,minlat=0,avglat=2,maxlat=3)`

## Reviewers
@panchr 
@austin-zhu
@Jason-Jian 