### PR TITLE
Remove usage of git in gemspec

### DIFF
--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/airbnb/synapse"
 
   gem.files         = Dir["**/*"]
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.executables   = Dir["bin/**/*"].map{ |f| File.basename(f) }
+  gem.test_files    = Dir["spec/**/*"]
 
   gem.add_runtime_dependency "aws-sdk", "~> 1.39"
   gem.add_runtime_dependency "docker-api", "~> 1.7"

--- a/synapse.gemspec
+++ b/synapse.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Dynamic HAProxy configuration daemon}
   gem.homepage      = "https://github.com/airbnb/synapse"
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = Dir["**/*"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
 


### PR DESCRIPTION
## Summary

Using `git` within the `gemspec` makes it coupled with the repository being cloned---the "source" of the project itself is no longer sufficient just to build the gem. This also makes it harder to build the gem in CI where the git repository itself may not be present.

## Testing
Original:
```bash
$ docker run  --rm -it -v `pwd`:/test ruby:2.3.0 bash -c "cd /test && gem build synapse.gemspec && gem install synapse*.gem && rm synapse-*.gem && synapse --help"
...
14 gems installed
Welcome to synapse

Usage: synapse --config /path/to/synapse/config
    -c, --config config              path to synapse config
    -h, --help                       Display this screen
```

New:
```bash
$ docker run  --rm -it -v `pwd`:/test ruby:2.3.0 bash -c "cd /test && gem build synapse.gemspec && gem install synapse*.gem && rm synapse-*.gem && synapse --help"
...
14 gems installed
Welcome to synapse

Usage: synapse --config /path/to/synapse/config
    -c, --config config              path to synapse config
    -h, --help                       Display this screen
```

## Reviewers
@austin-zhu @Jason-Jian 