### PR TITLE
Do not wait on threads in Zookeeper watchers

### DIFF
--- a/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
+++ b/lib/synapse/service_watcher/multi/resolver/s3_toggle.rb
@@ -176,13 +176,6 @@ class Synapse::ServiceWatcher::Resolver
 
       def stop
         @mu.synchronize { @should_exit = true }
-
-        # This will kill the thread even though other resolvers are potentially
-        # still using the singleton. However, that is fine to do because in Synapse,
-        # stop is called all at once---all watchers will be stopped when Synapse
-        # stops.
-        @thread.join unless @thread.nil?
-        @thread = nil
       end
 
       private

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -80,7 +80,6 @@ class Synapse::ServiceWatcher
       log.warn "synapse: zookeeper watcher exiting"
 
       @should_exit.set(true)
-      @thread.join unless @thread.nil?
 
       zk_teardown do
         @watcher.unsubscribe unless @watcher.nil?

--- a/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
@@ -50,7 +50,6 @@ class Synapse::ServiceWatcher
         # Signal to the thread that it should exit, and then wait for it to
         # exit.
         @should_exit.set(true)
-        @thread.join unless @thread.nil?
       end
     end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.3"
+  VERSION = "0.18.4"
 end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -329,15 +329,6 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
         subject.instance_variable_set(:@thread, thread)
       end
 
-      it 'stops the thread' do
-        expect(thread).to receive(:join).exactly(:once)
-        subject.instance_variable_set(:@callback_count, 5)
-
-        (1..5).each do
-          subject.stop
-        end
-      end
-
       context 'when thread does not exist' do
         let(:thread) { nil }
 

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -650,18 +650,6 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         end
       end
 
-      context 'when thread is running' do
-        before :each do
-          subject.instance_variable_set(:@thread, mock_thread)
-          subject.instance_variable_set(:@zk, mock_zk.as_null_object)
-        end
-
-        it 'kills the thread' do
-          expect(mock_thread).to receive(:join).exactly(:once)
-          subject.stop
-        end
-      end
-
       context 'when thread is not running' do
         before :each do
           subject.instance_variable_set(:@zk, mock_zk.as_null_object)


### PR DESCRIPTION
## Summary
Because of the sleep duration (set to 0.5s) in `ZookeeperWatcher` and `ZookeeperPollWatcher`, killing the thread for either will take an average of `0.25s`. Synapse's shutdown sequence will call every watcher's `stop` sequentially.

This means that **for every one of these watchers the Synapse shutdown time increases by ~0.25s**. With one usage of 3000 watchers + another 3000 dual-read watchers, Synapse shutdown can take nearly 25 minutes:

*Note: shutdown starts when thread count starts decreasing, and finishes when thread count increases again (i.e. restarted)*

![image](https://user-images.githubusercontent.com/6776539/89193446-fd8c3100-d573-11ea-97ad-97037b41b5a9.png)

### Fix
I removed the `Thread.join` calls which are not really necessary. In Synapse's current design, watchers are only shutdown when the whole process is being shutdown. As such, all the threads are forcefully killed at process exit.
Gracefully shutting down the threads is not too important because they do not have any external state to cleanup (outside of the Synapse process itself).

This decreases process shutdown time to <= 30 seconds (note the graph has a very x-axis different scale)

![image](https://user-images.githubusercontent.com/6776539/89195953-86f13280-d577-11ea-94ec-8c4de2a5d020.png)


## Reviewers
@austin-zhu @Jason-Jian 