### PR TITLE
Reduce zk calls with enhanced zk event processing

### DIFF
--- a/lib/synapse/service_watcher/base/base.rb
+++ b/lib/synapse/service_watcher/base/base.rb
@@ -231,7 +231,7 @@ class Synapse::ServiceWatcher
       return true
     end
 
-    def update_config_for_generator(new_config_for_generator)
+    def update_config_for_generator(new_config_for_generator, do_reconfigure=false)
       if new_config_for_generator.empty?
         log.info "synapse: no config_for_generator data from #{name} for" \
               " service #{@name}; keep existing config_for_generator"
@@ -245,6 +245,9 @@ class Synapse::ServiceWatcher
           return false
         else
           @config_for_generator.set(new_config_for_generator)
+          if do_reconfigure
+            reconfigure!
+          end
           return true
         end
       end

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -113,38 +113,55 @@ class Synapse::ServiceWatcher
     end
 
     # find the current backends at the discovery path
-    def discover(zookeeper_opts={:watch => true})
+    def discover(zookeeper_opts={:watch => true}, zk_event=nil)
       statsd_increment('synapse.watcher.zk.discovery', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"])
       statsd_time('synapse.watcher.zk.discovery.elapsed_time', ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}", "service_name:#{@name}"]) do
         log.info "synapse: discovering backends for service #{@name}"
 
-        new_backends = []
-        zk_children = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
-            statsd_time('synapse.watcher.zk.children.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
-              log.info "synapse: zk list children at #{@discovery['path']} for #{attempts} times"
-              begin
-                @zk.children(@discovery['path'], zookeeper_opts)
-              rescue ZK::Exceptions::NoNode
-                log.error "synapse: zk list children failed with no node"
-                statsd_increment('synapse.watcher.zk.children.failed', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"])
-                []
+        # There are three possible cases, with each case exclusive to others.
+        # 1. No zk event, read data with both data/child watches registered
+        # 2. Registered child watch fired, need_get_children is set to true and children are read from zk with new child watch registered.
+        # 3. Registered data watch fired, need_read_config is set to true and znode is read from zk with new data watch registered.
+        need_get_children = zk_event.nil? || zk_event.node_child?
+        need_read_config = zk_event.nil? || zk_event.node_changed? || zk_event.node_created? || zk_event.node_deleted?
+
+        log.info "synapse: read children: #{need_get_children}, read config: #{need_read_config}"
+
+        new_backends = nil
+        if need_get_children
+          new_backends = []
+          zk_children = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
+              statsd_time('synapse.watcher.zk.children.elapsed_time', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"]) do
+                log.info "synapse: zk list children at #{@discovery['path']} for #{attempts} times"
+                begin
+                  @zk.children(@discovery['path'], zookeeper_opts)
+                rescue ZK::Exceptions::NoNode
+                  log.error "synapse: zk list children failed with no node"
+                  statsd_increment('synapse.watcher.zk.children.failed', ["zk_cluster:#{@zk_cluster}", "service_name:#{@name}"])
+                  []
+                end
               end
-            end
-        end
-        statsd_gauge('synapse.watcher.zk.children.bytes', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
+          end
+          statsd_gauge('synapse.watcher.zk.children.bytes', ObjectSpace.memsize_of(zk_children), ["zk_cluster:#{@zk_cluster}", "zk_path:#{@discovery['path']}"])
 
-        zk_children.each do |id|
-          backend = read_child_data(id)
-          new_backends << backend unless backend.nil?
+          zk_children.each do |id|
+            backend = read_child_data(id)
+            new_backends << backend unless backend.nil?
+          end
         end
 
-        new_config_for_generator = read_config_for_generator(zookeeper_opts)
-        set_backends(new_backends, new_config_for_generator)
+        new_config_for_generator = need_read_config ? read_config_for_generator(zookeeper_opts) : {}
+
+        if new_backends.nil?
+          update_config_for_generator(new_config_for_generator, true)
+        else
+          set_backends(new_backends, new_config_for_generator)
+        end
       end
     end
 
     # sets up zookeeper callbacks if the data at the discovery path changes
-    def watch
+    def watch(zk_event=nil)
       return if @zk.nil?
       log.debug "synapse: setting watch at #{@discovery['path']}"
 
@@ -154,11 +171,19 @@ class Synapse::ServiceWatcher
           @watcher = @zk.register(@discovery['path'], &watcher_callback)
         end
 
-        # Verify that we actually set up the watcher.
-        existed = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
-          log.info "synapse: zk exists at #{@discovery['path']} for #{attempts} times"
-          @zk.exists?(@discovery['path'], :watch => true)
+        # There are two cases when new watch needs to be created in zk, otherwise watch already exists.
+        # 1. Create watch in zk when zk event is nil
+        # 2. Create watch again when current event is triggered by existing watch. 
+        existed = true
+        need_exists_watch = zk_event.nil? || zk_event.node_changed? || zk_event.node_created? || zk_event.node_deleted?
+        if need_exists_watch
+          # Verify that we actually set up the watcher.
+          existed = with_retry(@retry_policy.merge({'retriable_errors' => ZK_RETRIABLE_ERRORS})) do |attempts|
+            log.info "synapse: zk exists at #{@discovery['path']} for #{attempts} times"
+            @zk.exists?(@discovery['path'], :watch => true)
+          end
         end
+
         unless existed
           log.error "synapse: zookeeper watcher path #{@discovery['path']} does not exist!"
           statsd_increment('synapse.watcher.zk.register_failed')
@@ -196,9 +221,9 @@ class Synapse::ServiceWatcher
             log.warn "synapse: invalid discovery_jitter=#{@discovery['discovery_jitter']} for service:#{@name}"
           end
         end
-        watch
+        watch(event)
         # Rediscover
-        discover
+        discover({:watch => true}, event)
       end
     end
 

--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -121,11 +121,11 @@ class Synapse::ServiceWatcher
         # There are three possible cases, with each case exclusive to others.
         # 1. No zk event, read data with both data/child watches registered
         # 2. Registered child watch fired, need_get_children is set to true and children are read from zk with new child watch registered.
-        # 3. Registered data watch fired, need_read_config is set to true and znode is read from zk with new data watch registered.
+        # 3. Registered data watch fired, need_update_config is set to true and znode is read from zk with new data watch registered.
         need_get_children = zk_event.nil? || zk_event.node_child?
-        need_read_config = zk_event.nil? || zk_event.node_changed? || zk_event.node_created? || zk_event.node_deleted?
+        need_update_config = zk_event.nil? || zk_event.node_changed? || zk_event.node_created? || zk_event.node_deleted?
 
-        log.info "synapse: read children: #{need_get_children}, read config: #{need_read_config}"
+        log.info "synapse: read children: #{need_get_children}, update config: #{need_update_config}"
 
         new_backends = nil
         if need_get_children
@@ -150,7 +150,7 @@ class Synapse::ServiceWatcher
           end
         end
 
-        new_config_for_generator = need_read_config ? read_config_for_generator(zookeeper_opts) : {}
+        new_config_for_generator = need_update_config ? read_config_for_generator(zookeeper_opts) : {}
 
         if new_backends.nil?
           update_config_for_generator(new_config_for_generator, true)

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.6"
+  VERSION = "0.18.7"
 end

--- a/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
+++ b/spec/lib/synapse/multi_resolver/s3_toggle_spec.rb
@@ -480,7 +480,10 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
             results[k] = 0
           end
 
-          (0..1000).each do
+          count_of_test = 2000
+          count_of_diff_to_pass = count_of_test / 10
+
+          (1..count_of_test).each do
             choice = subject.send(:pick_watcher, distribution)
             results[choice] += 1
           end
@@ -488,7 +491,7 @@ describe Synapse::ServiceWatcher::Resolver::S3ToggleResolver do
           # check distribution of results instead of actual choices
           expect(results['primary']).to be > 0
           expect(results['secondary']).to be > 0
-          expect(results['secondary']).to be_within(100).of(results['primary'])
+          expect(results['secondary']).to be_within(count_of_diff_to_pass).of(results['primary'])
         end
       end
 


### PR DESCRIPTION
### Summary

Current ZookeeperWatcher's watch_callback accepts zk event as parameter but ignores it during processing. Every time a zk event is received, watch_callback does all three things regardless of which zk event:

- calling zk.exists on service znode
- calling zk.children on service znode
- calling zk.get on service znode.

But each zk event always contains single change(e.g. child and data event are mutually exclusive) and performing all three calls above are not necessary. For example below are a list of methods supported on zk event:

- node_event? : true for node event and false for session event
- node_child? : true if watched znode children have changed.
- node_chanaged? : true if watched znode data has changed.
- node_created? : true if watched znode was created 
- node_deleted? : true if watched znode was deleted.

This PR adds a few boolean checks to handle children change and data change separately, and should reduce three zk calls to one in most cases since children change is the most frequent ones.

During watch startup, the three calls will still be executed to read data and set watches in zk.

### Test
- Added new rspec tests to test nil/child/changed events: bundle exec rspec
- Ran ZookeeperWatcher against zookeeper-test and checked event handling with manual zk data change.


### Reviewer
@airbnb/traffic
@panchr 
@austin-zhu 
@Jason-Jian
