### PR TITLE
Properly obtain config_for_generator in ZookeeperDnsWatcher

### DIFF
--- a/lib/synapse/service_watcher/dns/dns.rb
+++ b/lib/synapse/service_watcher/dns/dns.rb
@@ -84,7 +84,7 @@ class Synapse::ServiceWatcher
       Resolv::DNS.open(*args)
     end
 
-    def configure_backends(servers)
+    def configure_backends(servers, config_for_generator={})
       new_backends = servers.flat_map do |(server, addresses)|
         addresses.map do |address|
           {
@@ -96,7 +96,7 @@ class Synapse::ServiceWatcher
         end
       end
 
-      set_backends(new_backends)
+      set_backends(new_backends, config_for_generator)
     end
   end
 end

--- a/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
@@ -149,6 +149,10 @@ class Synapse::ServiceWatcher
       @zk.stop
     end
 
+    def config_for_generator
+      @zk.config_for_generator
+    end
+
     def backends
       @dns.backends
     end

--- a/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
@@ -15,7 +15,7 @@ class Synapse::ServiceWatcher
       Synapse::ServiceWatcher::ZookeeperPollWatcher.new(
         mk_child_watcher_opts(zookeeper_discovery_opts),
         @synapse,
-        ->(backends, config_for_generator, *args) { update_dns_watcher(queue, config_for_generator, backends) },
+        ->(backends, config_for_generator, *args) { update_dns_watcher(queue, backends, config_for_generator) },
       )
     end
 

--- a/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns_poll/zookeeper_dns_poll.rb
@@ -15,7 +15,7 @@ class Synapse::ServiceWatcher
       Synapse::ServiceWatcher::ZookeeperPollWatcher.new(
         mk_child_watcher_opts(zookeeper_discovery_opts),
         @synapse,
-        ->(backends, *args) { update_dns_watcher(queue, backends) },
+        ->(backends, config_for_generator, *args) { update_dns_watcher(queue, config_for_generator, backends) },
       )
     end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.4"
+  VERSION = "0.18.5"
 end

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -872,6 +872,21 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
         zk.send(:set_backends, backends)
       end
     end
+
+    context 'with config in Zookeeper' do
+      let(:mock_config_for_generator) { {"haproxy" => "blah blah", "port" => 7007} }
+
+      it 'returns config_for_generator from ZookeeperWatcher' do
+        allow(Synapse::ServiceWatcher::ZookeeperWatcher).to receive(:new).and_return(mock_zk)
+        allow(Synapse::ServiceWatcher::DnsWatcher).to receive(:new).and_return(mock_dns)
+        allow(mock_zk).to receive(:config_for_generator).and_return(mock_config_for_generator)
+        allow(mock_zk).to receive(:start)
+        allow(mock_dns).to receive(:start)
+
+        subject.start
+        expect(subject.config_for_generator).to eq(mock_config_for_generator)
+      end
+    end
   end
 
   describe 'ZookeeperDnsPollWatcher' do

--- a/spec/lib/synapse/service_watcher_zookeeper_spec.rb
+++ b/spec/lib/synapse/service_watcher_zookeeper_spec.rb
@@ -879,7 +879,7 @@ describe Synapse::ServiceWatcher::ZookeeperWatcher do
       let(:mock_zk_client) { double(ZK) }
 
       after :each do
-        Synapse::ServiceWatcher::Zookeeper.class_variable_set(:@@zk_pool, {})
+        Synapse::ServiceWatcher::ZookeeperWatcher.class_variable_set(:@@zk_pool, {})
       end
 
       it 'returns config_for_generator from ZookeeperWatcher' do


### PR DESCRIPTION
## Summary
Fix a bug in `ZookeeperDnsWatcher` that prevents `frontend` stanzas from being generated in HAProxy. This is a consequence of the fact that this watcher does not expose the `config_for_generator` that is read from Zookeeper.

The fix does the following:
1. Expose `config_for_generator` from `ZookeeperWatcher`
2. Ensure that when the `ZookeeperWatcher`'s `config_for_generator` changes (without a backend change), a notification and re-configuration is triggered

## Testing
- [x] CI
- [x] `frontend` stanzas are properly generated
```
# BEFORE
$  grep -c frontend /etc/haproxy/haproxy.cfg
1

# the "frontend" is not the stanza but just present in the log-format
$ grep frontend /etc/haproxy/haproxy.cfg
#         log-format {"accept_date":"%t","actconn":%ac,"backend_name":"%b","backend_queue":%bq,"beconn":%bc,"bytes_read":%B,"captured_request_cookie":"%CC","captured_response_cookie":"%CS","client_ip":"%ci","client_port":"%cp","feconn":"%fc","frontend_name":"%f","http_request":"%r","http_status_code":"%ST","retries":"%rc","server_name":"%s","srv_queue":"%sq","srvconn":%sc,"termination_state":"%ts","time_backend_connect":"%Tc","time_backend_response":"%Tr","time_duration":"%Tt","time_request":"%Tq","time_queue":%Tw}

# AFTER
$ grep -c frontend /etc/haproxy/haproxy.cfg
10
```

## Reviewers
@austin-zhu @Jason-Jian 