### PR TITLE
Block on watcher start to alleviate HAProxy config generator race condition

### DIFF
--- a/lib/synapse/service_watcher/zookeeper/zookeeper.rb
+++ b/lib/synapse/service_watcher/zookeeper/zookeeper.rb
@@ -66,13 +66,7 @@ class Synapse::ServiceWatcher
       # Zookeeper processing is run in a background thread so that any retries
       # do not block the main thread.
       zk_connect do
-        @thread = Thread.new {
-          start_discovery
-
-          until @should_exit.get
-            sleep 0.5
-          end
-        }
+        start_discovery
       end
     end
 

--- a/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
+++ b/lib/synapse/service_watcher/zookeeper_poll/zookeeper_poll.rb
@@ -20,11 +20,14 @@ class Synapse::ServiceWatcher
       log.info 'synapse: ZookeeperPollWatcher starting'
 
       zk_connect do
+        # Perform an initial discover so that we have a config_for_generator before
+        # start exits.
+        discover
+
         @thread = Thread.new {
           log.info 'synapse: zookeeper polling thread started'
 
-          # Ensure we poll on first start.
-          last_run = Time.now - @poll_interval - 1
+          last_run = Time.now
 
           until @should_exit.get
             now = Time.now

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.5"
+  VERSION = "0.18.6"
 end


### PR DESCRIPTION
## Summary
Due to a race condition in the HAProxy config generator, each watcher `start` method should block until there is an initial discover performed. In particular, the watcher needs to have the `config_for_generator` set before it should return from startup.

The race condition occurs due to how the config generator reads the data at [different](https://github.com/airbnb/synapse/blob/5363ac045f13903623c8d40e89f4b85786945e75/lib/synapse/config_generator/haproxy.rb#L933) [times](https://github.com/airbnb/synapse/blob/5363ac045f13903623c8d40e89f4b85786945e75/lib/synapse/config_generator/haproxy.rb#L1007) [for](https://github.com/airbnb/synapse/blob/5363ac045f13903623c8d40e89f4b85786945e75/lib/synapse/config_generator/haproxy.rb#L933) [different](https://github.com/airbnb/synapse/blob/5363ac045f13903623c8d40e89f4b85786945e75/lib/synapse/config_generator/haproxy.rb#L1470) purposes, even though treats the data as being the same.

This reverts the thread use change (introduced with dual-read) specifically for the `ZookeeperWatcher`.

*Note:* the race condition in `HAProxy` config generator still exists. However, since the `ZK` watchers are the only ones that produce `config_for_generator`s, it should not occur as long as `config_for_generator` is never the default value.

## Testing
Initially, cannot talk to a Synapse-backed dependency through HAProxy when Synapse first starts:

```bash
$ sudo service synapse restart
ok: run: synapse: 1s
$ curl -i http://my-dependency:8080/health
curl: (7) Failed to connect to my-dependency port 8080: Connection refused

# but reloading HAProxy fixes the issue
$ sudo service haproxy reload
 * Reloading haproxy haproxy                                                                  [ OK ]
$ curl -i http://my-dependency:8080/health
HTTP/1.1 404 Not Found
date: Fri, 28 Aug 2020 15:25:07 GMT
...
```

### After
With this patch applied, the `curl` works without needing to manually restart HAProxy:

```bash
$ sudo service synapse restart
ok: run: synapse: 0s
$ curl -i http://my-dependency:8080/health
HTTP/1.1 404 Not Found
date: Fri, 28 Aug 2020 15:29:21 GMT
```

## Reviewers
@Jason-Jian @austin-zhu 