### PR TITLE
Ensure watchers exist in ZookeeperDnsWatcher

### DIFF
--- a/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
+++ b/lib/synapse/service_watcher/zookeeper_dns/zookeeper_dns.rb
@@ -111,13 +111,17 @@ class Synapse::ServiceWatcher
       end
     end
 
-    def start
+    def initialize(opts={}, synapse, reconfigure_callback)
+      super(opts, synapse, reconfigure_callback)
+
       @check_interval = @discovery['check_interval'] || 30.0
       @message_queue = Queue.new
 
       @dns = make_dns_watcher(@message_queue)
       @zk = make_zookeeper_watcher(@message_queue)
+    end
 
+    def start
       @zk.start
       @dns.start
 


### PR DESCRIPTION
## Summary
Fix race condition when starting up `ZookeeperDnsWatcher`. The race condition is that `@dns` will not exist by the time that `@zk` calls its `reconfigure_callback`, which in turn will call `@dns.backends`.

This was introduced in #333; since the `ZK` watchers will always discover first before completing `start`, they will always call `reconfigure_callback` on startup.

## Testing
Previously during startup, this error was received when using `ZookeeperDnsWatcher`:
```E, [2020-08-31T09:42:40.828903 #8859] ERROR -- Synapse::Synapse: synapse: encountered unexpected exception #<NoMethodError: undefined method `backends' for nil:NilClass> in main thread```

Now, Synapse starts up properly.

## Reviewers
@austin-zhu