### PR TITLE
Add metrics for DNS resolve failure. 

### DIFF
--- a/lib/synapse/service_watcher/dns/dns.rb
+++ b/lib/synapse/service_watcher/dns/dns.rb
@@ -44,7 +44,7 @@ class Synapse::ServiceWatcher
 
           sleep_until_next_check(start)
         rescue => e
-          log.warn "Error in watcher thread: #{e.inspect}"
+          log.warn "synapse: dns error in watcher thread: #{e.inspect}"
           log.warn e.backtrace
         end
       end
@@ -75,7 +75,8 @@ class Synapse::ServiceWatcher
         return resolution
       end
     rescue => e
-      log.warn "Error while resolving host names: #{e.inspect}"
+      statsd_increment('synapse.watcher.dns.resolve_failed', ["service_name:#{@name}"])
+      log.warn "synapse: dns resolve error while resolving host names: #{e.inspect}"
       []
     end
 

--- a/lib/synapse/version.rb
+++ b/lib/synapse/version.rb
@@ -1,3 +1,3 @@
 module Synapse
-  VERSION = "0.18.8"
+  VERSION = "0.18.9"
 end


### PR DESCRIPTION
#### Summary
Add metrics for DNS resolve failure so that it's easier to capture. Also add synapse prefix for legacy logs. 

#### Test
- [X] CI
- [X] Unit Test
```
$ bundle exec rspec

Finished in 0.51704 seconds (files took 1.17 seconds to load)
418 examples, 0 failures
```

#### Reviewer
@panchr 